### PR TITLE
feat: add support for viewing read-only channels where appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,30 @@ ARGUMENTS
   IDORINDEX  the channel id or number in list
 
 OPTIONS
-  -h, --help             show CLI help
-  -j, --json             use JSON format of input and/or output
-  -o, --output=output    specify output file
-  -p, --profile=profile  [default: default] configuration profile
-  -t, --token=token      the auth token to use
-  -y, --yaml             use YAML format of input and/or output
-  --compact              use compact table format with no lines between body rows
-  --expanded             use expanded table format with a line between each body row
-  --indent=indent        specify indentation for formatting JSON or YAML output
-  --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+  -I, --include-read-only  include subscribed-to channels as well as owned channels
+  -h, --help               show CLI help
+  -j, --json               use JSON format of input and/or output
+  -o, --output=output      specify output file
+  -p, --profile=profile    [default: default] configuration profile
+  -t, --token=token        the auth token to use
+  -y, --yaml               use YAML format of input and/or output
+  --compact                use compact table format with no lines between body rows
+  --expanded               use expanded table format with a line between each body row
+  --indent=indent          specify indentation for formatting JSON or YAML output
+  --language=language      ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+
+EXAMPLE
+  # list all user-owned channels
+  $ smartthings edge:channels
+
+  # list user-owned and subscribed channels
+  $ smartthings edge:channels --include-read-only
+
+  # display details about the second channel listed when running "smartthings edge:channels"
+  $ smartthings edge:channels 2
 ```
 
-_See code: [dist/commands/edge/channels.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels.ts)_
+_See code: [dist/commands/edge/channels.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels.ts)_
 
 ## `smartthings edge:channels:assign [DRIVERID] [VERSION]`
 
@@ -91,7 +102,7 @@ ALIASES
   $ smartthings edge:drivers:publish
 ```
 
-_See code: [dist/commands/edge/channels/assign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels/assign.ts)_
+_See code: [dist/commands/edge/channels/assign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels/assign.ts)_
 
 ## `smartthings edge:channels:create`
 
@@ -116,7 +127,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [dist/commands/edge/channels/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels/create.ts)_
+_See code: [dist/commands/edge/channels/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels/create.ts)_
 
 ## `smartthings edge:channels:delete [ID]`
 
@@ -136,7 +147,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [dist/commands/edge/channels/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels/delete.ts)_
+_See code: [dist/commands/edge/channels/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels/delete.ts)_
 
 ## `smartthings edge:channels:drivers [IDORINDEX]`
 
@@ -165,7 +176,7 @@ ALIASES
   $ smartthings edge:channels:assignments
 ```
 
-_See code: [dist/commands/edge/channels/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels/drivers.ts)_
+_See code: [dist/commands/edge/channels/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels/drivers.ts)_
 
 ## `smartthings edge:channels:enroll [HUBID]`
 
@@ -186,7 +197,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [dist/commands/edge/channels/enroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels/enroll.ts)_
+_See code: [dist/commands/edge/channels/enroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels/enroll.ts)_
 
 ## `smartthings edge:channels:enrollments [IDORINDEX]`
 
@@ -212,7 +223,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [dist/commands/edge/channels/enrollments.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels/enrollments.ts)_
+_See code: [dist/commands/edge/channels/enrollments.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels/enrollments.ts)_
 
 ## `smartthings edge:channels:invites [IDORINDEX]`
 
@@ -249,7 +260,7 @@ EXAMPLES
   smartthings edge:channels:invites <invite id>      # list details about the invite with id <invite id>
 ```
 
-_See code: [dist/commands/edge/channels/invites.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels/invites.ts)_
+_See code: [dist/commands/edge/channels/invites.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels/invites.ts)_
 
 ## `smartthings edge:channels:invites:accept ID`
 
@@ -272,7 +283,7 @@ ALIASES
   $ smartthings edge:channels:invitations:accept
 ```
 
-_See code: [dist/commands/edge/channels/invites/accept.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels/invites/accept.ts)_
+_See code: [dist/commands/edge/channels/invites/accept.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels/invites/accept.ts)_
 
 ## `smartthings edge:channels:invites:create`
 
@@ -300,7 +311,7 @@ ALIASES
   $ smartthings edge:channels:invitations:create
 ```
 
-_See code: [dist/commands/edge/channels/invites/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels/invites/create.ts)_
+_See code: [dist/commands/edge/channels/invites/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels/invites/create.ts)_
 
 ## `smartthings edge:channels:invites:delete [ID]`
 
@@ -326,7 +337,7 @@ ALIASES
   $ smartthings edge:channels:invites:revoke
 ```
 
-_See code: [dist/commands/edge/channels/invites/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels/invites/delete.ts)_
+_See code: [dist/commands/edge/channels/invites/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels/invites/delete.ts)_
 
 ## `smartthings edge:channels:unassign [DRIVERID]`
 
@@ -350,7 +361,7 @@ ALIASES
   $ smartthings edge:drivers:unpublish
 ```
 
-_See code: [dist/commands/edge/channels/unassign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels/unassign.ts)_
+_See code: [dist/commands/edge/channels/unassign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels/unassign.ts)_
 
 ## `smartthings edge:channels:unenroll [HUBID]`
 
@@ -371,7 +382,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [dist/commands/edge/channels/unenroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels/unenroll.ts)_
+_See code: [dist/commands/edge/channels/unenroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels/unenroll.ts)_
 
 ## `smartthings edge:channels:update [ID]`
 
@@ -399,7 +410,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [dist/commands/edge/channels/update.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/channels/update.ts)_
+_See code: [dist/commands/edge/channels/update.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/channels/update.ts)_
 
 ## `smartthings edge:drivers [IDORINDEX]`
 
@@ -425,7 +436,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [dist/commands/edge/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/drivers.ts)_
+_See code: [dist/commands/edge/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/drivers.ts)_
 
 ## `smartthings edge:drivers:delete [ID]`
 
@@ -445,7 +456,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [dist/commands/edge/drivers/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/drivers/delete.ts)_
+_See code: [dist/commands/edge/drivers/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/drivers/delete.ts)_
 
 ## `smartthings edge:drivers:install [DRIVERID]`
 
@@ -474,7 +485,7 @@ EXAMPLES
   enrolled hub
 ```
 
-_See code: [dist/commands/edge/drivers/install.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/drivers/install.ts)_
+_See code: [dist/commands/edge/drivers/install.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/drivers/install.ts)_
 
 ## `smartthings edge:drivers:installed [IDORINDEX]`
 
@@ -501,7 +512,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [dist/commands/edge/drivers/installed.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/drivers/installed.ts)_
+_See code: [dist/commands/edge/drivers/installed.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/drivers/installed.ts)_
 
 ## `smartthings edge:drivers:logcat [DRIVERID]`
 
@@ -523,7 +534,7 @@ OPTIONS
   --language=language        ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [dist/commands/edge/drivers/logcat.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/drivers/logcat.ts)_
+_See code: [dist/commands/edge/drivers/logcat.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/drivers/logcat.ts)_
 
 ## `smartthings edge:drivers:package [PROJECTDIRECTORY]`
 
@@ -575,9 +586,6 @@ EXAMPLE
   # build and upload driver found in current directory:
   $ smartthings edge:drivers:package
 
-  # build and upload driver found in current directory:
-  $ smartthings edge:drivers:package
-
   # build and upload driver found in current directory, assign it to a channel, and install it;
   # user will be prompted for channel and hub
   $ smartthings edge:drivers:package -I
@@ -596,7 +604,7 @@ EXAMPLE
   $ smartthings edge:drivers:package -u driver.zip
 ```
 
-_See code: [dist/commands/edge/drivers/package.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/drivers/package.ts)_
+_See code: [dist/commands/edge/drivers/package.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/drivers/package.ts)_
 
 ## `smartthings edge:drivers:uninstall [DRIVERID]`
 
@@ -617,7 +625,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [dist/commands/edge/drivers/uninstall.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.1.0/dist/commands/edge/drivers/uninstall.ts)_
+_See code: [dist/commands/edge/drivers/uninstall.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.3.0/dist/commands/edge/drivers/uninstall.ts)_
 <!-- commandsstop -->
 
 # Building

--- a/src/commands/edge/channels.ts
+++ b/src/commands/edge/channels.ts
@@ -1,24 +1,38 @@
-import { ChooseOptions, chooseOptionsWithDefaults, outputListing, selectFromList, stringTranslateToId } from '@smartthings/cli-lib'
+import { flags } from '@oclif/command'
+
+import { ChooseOptions, chooseOptionsWithDefaults, outputListing, selectFromList,
+	stringTranslateToId } from '@smartthings/cli-lib'
 
 import { EdgeCommand } from '../../lib/edge-command'
 import { Channel } from '../../lib/endpoints/channels'
 
 
-export async function chooseChannel(command: EdgeCommand, promptMessage: string, channelFromArg?: string, options?: Partial<ChooseOptions>): Promise<string> {
-	const opts = chooseOptionsWithDefaults(options)
+interface ChooseChannelOptions extends ChooseOptions {
+	includeReadOnly: boolean
+}
+const chooseChannelOptionsWithDefaults = (options?: Partial<ChooseChannelOptions>): ChooseChannelOptions => ({
+	includeReadOnly: false,
+	...chooseOptionsWithDefaults(options),
+})
+export async function chooseChannel(command: EdgeCommand, promptMessage: string,
+		channelFromArg?: string, options?: Partial<ChooseChannelOptions>): Promise<string> {
+	const opts = chooseChannelOptionsWithDefaults(options)
 	const config = {
 		itemName: 'channel',
 		primaryKeyName: 'channelId',
 		sortKeyName: 'name',
 	}
-	const listChannels = (): Promise<Channel[]> => command.edgeClient.channels.list()
+	const listChannels = (): Promise<Channel[]> => command.edgeClient.channels.list({
+		includeReadOnly: opts.includeReadOnly,
+	})
 	const preselectedId = opts.allowIndex
 		? await stringTranslateToId(config, channelFromArg, listChannels)
 		: channelFromArg
 	return selectFromList(command, config, preselectedId, listChannels, promptMessage)
 }
 
-export const listTableFieldDefinitions = ['channelId', 'name', 'description', 'termsOfServiceUrl', 'createdDate', 'lastModifiedDate']
+export const listTableFieldDefinitions = ['channelId', 'name', 'description', 'termsOfServiceUrl',
+	'createdDate', 'lastModifiedDate']
 export const tableFieldDefinitions = listTableFieldDefinitions
 
 
@@ -28,12 +42,25 @@ export default class ChannelsCommand extends EdgeCommand {
 	static flags = {
 		...EdgeCommand.flags,
 		...outputListing.flags,
+		'include-read-only': flags.boolean({
+			char: 'I',
+			description: 'include subscribed-to channels as well as owned channels',
+		}),
 	}
 
 	static args = [{
 		name: 'idOrIndex',
 		description: 'the channel id or number in list',
 	}]
+
+	static examples = [`# list all user-owned channels
+$ smartthings edge:channels
+
+# list user-owned and subscribed channels
+$ smartthings edge:channels --include-read-only
+
+# display details about the second channel listed when running "smartthings edge:channels"
+$ smartthings edge:channels 2`]
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(ChannelsCommand)
@@ -47,7 +74,7 @@ export default class ChannelsCommand extends EdgeCommand {
 		}
 
 		await outputListing(this, config, args.idOrIndex,
-			() => this.edgeClient.channels.list(),
+			() => this.edgeClient.channels.list({ includeReadOnly: flags['include-read-only'] }),
 			id => this.edgeClient.channels.get(id))
 	}
 }

--- a/src/commands/edge/channels/drivers.ts
+++ b/src/commands/edge/channels/drivers.ts
@@ -29,7 +29,8 @@ export default class ChannelsDriversCommand extends EdgeCommand {
 			listTableFieldDefinitions: ['channelId', 'driverId', 'version', 'createdDate', 'lastModifiedDate'],
 		}
 
-		const channelId = await chooseChannel(this, 'Select a channel.', args.idOrIndex, { allowIndex: true })
+		const channelId = await chooseChannel(this, 'Select a channel.', args.idOrIndex,
+			{ allowIndex: true, includeReadOnly: true })
 
 		await outputList(this, config, () => this.edgeClient.channels.listAssignedDrivers(channelId))
 	}

--- a/src/commands/edge/channels/enroll.ts
+++ b/src/commands/edge/channels/enroll.ts
@@ -27,7 +27,8 @@ export class ChannelsEnrollCommand extends EdgeCommand {
 		const { args, argv, flags } = this.parse(ChannelsEnrollCommand)
 		await super.setup(args, argv, flags)
 
-		const channelId = await chooseChannel(this, 'Select a channel.', flags.channel)
+		const channelId = await chooseChannel(this, 'Select a channel.', flags.channel,
+			{ includeReadOnly: true })
 		const hubId = await chooseHub(this, 'Select a hub.', args.hubId)
 
 		await this.edgeClient.channels.enrollHub(channelId, hubId)

--- a/src/commands/edge/channels/unenroll.ts
+++ b/src/commands/edge/channels/unenroll.ts
@@ -27,7 +27,8 @@ export class ChannelsUnenrollCommand extends EdgeCommand {
 		const { args, argv, flags } = this.parse(ChannelsUnenrollCommand)
 		await super.setup(args, argv, flags)
 
-		const channelId = await chooseChannel(this, 'Select a channel.', flags.channel)
+		const channelId = await chooseChannel(this, 'Select a channel.', flags.channel,
+			{ includeReadOnly: true })
 		const hubId = await chooseHub(this, 'Select a hub.', args.hubId)
 
 		await this.edgeClient.channels.unenrollHub(channelId, hubId)

--- a/src/commands/edge/drivers/package.ts
+++ b/src/commands/edge/drivers/package.ts
@@ -91,9 +91,6 @@ export default class PackageCommand extends EdgeCommand {
 	static examples = [`# build and upload driver found in current directory:
 $ smartthings edge:drivers:package
 
-# build and upload driver found in current directory:
-$ smartthings edge:drivers:package
-
 # build and upload driver found in current directory, assign it to a channel, and install it;
 # user will be prompted for channel and hub
 $ smartthings edge:drivers:package -I

--- a/src/lib/endpoints/channels.ts
+++ b/src/lib/endpoints/channels.ts
@@ -20,8 +20,10 @@ export interface Channel extends ChannelCreate {
 export type ChannelUpdate = ChannelCreate
 
 export interface ListOptions {
-	type?: 'HUB'
-	subscriberId?: string
+	/**
+	 * Include channels that have been subscribed to as well as user-owned channels.
+	 */
+	includeReadOnly?: boolean
 }
 
 export interface DriverChannelDetails {
@@ -68,11 +70,8 @@ export class ChannelsEndpoint extends Endpoint {
 
 	public async list(options: ListOptions = {}): Promise<Channel[]> {
 		const params: HttpClientParams = {}
-		if (options.type) {
-			params.type = options.type
-		}
-		if (options.subscriberId) {
-			params.subscriberId = options.subscriberId
+		if (typeof(options.includeReadOnly) === 'boolean') {
+			params.includeReadOnly = options.includeReadOnly.toString()
 		}
 		return this.client.getPagedItems('', params)
 	}


### PR DESCRIPTION
<!-- Describe your pull request. -->

* added option to endpoint to pass on `includeReadOnly` parameter (and removed options that don't exist)
* added `--include-read-only` (`-I`) option to `edge:channels` command to include accepted/read-only/subscribed channels in the list
* made use of new endpoint parameter for `edge:channels:enroll`, `edge:channels:unenroll` and `edge:channels:drivers` commands where including read-only channels makes sense
* removed duplicate example from `edge:drivers:package` command

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [X] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [X] Any required documentation has been added
- [ ] I have added tests to cover my changes
