### PR TITLE
feat: add config options for default hub and channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ EXAMPLE
   $ smartthings edge:channels 2
 ```
 
-_See code: [src/commands/edge/channels.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels.ts)_
+_See code: [src/commands/edge/channels.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels.ts)_
 
 ## `smartthings edge:channels:assign [DRIVERID] [VERSION]`
 
@@ -102,7 +102,7 @@ ALIASES
   $ smartthings edge:drivers:publish
 ```
 
-_See code: [src/commands/edge/channels/assign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels/assign.ts)_
+_See code: [src/commands/edge/channels/assign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels/assign.ts)_
 
 ## `smartthings edge:channels:create`
 
@@ -127,7 +127,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [src/commands/edge/channels/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels/create.ts)_
+_See code: [src/commands/edge/channels/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels/create.ts)_
 
 ## `smartthings edge:channels:delete [ID]`
 
@@ -147,7 +147,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [src/commands/edge/channels/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels/delete.ts)_
+_See code: [src/commands/edge/channels/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels/delete.ts)_
 
 ## `smartthings edge:channels:drivers [IDORINDEX]`
 
@@ -176,7 +176,7 @@ ALIASES
   $ smartthings edge:channels:assignments
 ```
 
-_See code: [src/commands/edge/channels/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels/drivers.ts)_
+_See code: [src/commands/edge/channels/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels/drivers.ts)_
 
 ## `smartthings edge:channels:enroll [HUBID]`
 
@@ -197,7 +197,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [src/commands/edge/channels/enroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels/enroll.ts)_
+_See code: [src/commands/edge/channels/enroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels/enroll.ts)_
 
 ## `smartthings edge:channels:enrollments [IDORINDEX]`
 
@@ -223,7 +223,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [src/commands/edge/channels/enrollments.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels/enrollments.ts)_
+_See code: [src/commands/edge/channels/enrollments.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels/enrollments.ts)_
 
 ## `smartthings edge:channels:invites [IDORINDEX]`
 
@@ -260,7 +260,7 @@ EXAMPLES
   smartthings edge:channels:invites <invite id>      # list details about the invite with id <invite id>
 ```
 
-_See code: [src/commands/edge/channels/invites.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels/invites.ts)_
+_See code: [src/commands/edge/channels/invites.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels/invites.ts)_
 
 ## `smartthings edge:channels:invites:accept ID`
 
@@ -283,7 +283,7 @@ ALIASES
   $ smartthings edge:channels:invitations:accept
 ```
 
-_See code: [src/commands/edge/channels/invites/accept.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels/invites/accept.ts)_
+_See code: [src/commands/edge/channels/invites/accept.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels/invites/accept.ts)_
 
 ## `smartthings edge:channels:invites:create`
 
@@ -294,6 +294,7 @@ USAGE
   $ smartthings edge:channels:invites:create
 
 OPTIONS
+  -C, --channel=channel  channel id
   -d, --dry-run          produce JSON but don't actually submit
   -h, --help             show CLI help
   -i, --input=input      specify input file
@@ -311,7 +312,7 @@ ALIASES
   $ smartthings edge:channels:invitations:create
 ```
 
-_See code: [src/commands/edge/channels/invites/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels/invites/create.ts)_
+_See code: [src/commands/edge/channels/invites/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels/invites/create.ts)_
 
 ## `smartthings edge:channels:invites:delete [ID]`
 
@@ -337,7 +338,7 @@ ALIASES
   $ smartthings edge:channels:invites:revoke
 ```
 
-_See code: [src/commands/edge/channels/invites/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels/invites/delete.ts)_
+_See code: [src/commands/edge/channels/invites/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels/invites/delete.ts)_
 
 ## `smartthings edge:channels:unassign [DRIVERID]`
 
@@ -361,7 +362,7 @@ ALIASES
   $ smartthings edge:drivers:unpublish
 ```
 
-_See code: [src/commands/edge/channels/unassign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels/unassign.ts)_
+_See code: [src/commands/edge/channels/unassign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels/unassign.ts)_
 
 ## `smartthings edge:channels:unenroll [HUBID]`
 
@@ -382,7 +383,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [src/commands/edge/channels/unenroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels/unenroll.ts)_
+_See code: [src/commands/edge/channels/unenroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels/unenroll.ts)_
 
 ## `smartthings edge:channels:update [ID]`
 
@@ -410,7 +411,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [src/commands/edge/channels/update.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/channels/update.ts)_
+_See code: [src/commands/edge/channels/update.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/channels/update.ts)_
 
 ## `smartthings edge:drivers [IDORINDEX]`
 
@@ -436,7 +437,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [src/commands/edge/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/drivers.ts)_
+_See code: [src/commands/edge/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/drivers.ts)_
 
 ## `smartthings edge:drivers:delete [ID]`
 
@@ -456,7 +457,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [src/commands/edge/drivers/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/drivers/delete.ts)_
+_See code: [src/commands/edge/drivers/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/drivers/delete.ts)_
 
 ## `smartthings edge:drivers:install [DRIVERID]`
 
@@ -485,7 +486,7 @@ EXAMPLES
   enrolled hub
 ```
 
-_See code: [src/commands/edge/drivers/install.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/drivers/install.ts)_
+_See code: [src/commands/edge/drivers/install.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/drivers/install.ts)_
 
 ## `smartthings edge:drivers:installed [IDORINDEX]`
 
@@ -512,7 +513,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [src/commands/edge/drivers/installed.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/drivers/installed.ts)_
+_See code: [src/commands/edge/drivers/installed.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/drivers/installed.ts)_
 
 ## `smartthings edge:drivers:logcat [DRIVERID]`
 
@@ -534,7 +535,7 @@ OPTIONS
   --language=language        ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [src/commands/edge/drivers/logcat.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/drivers/logcat.ts)_
+_See code: [src/commands/edge/drivers/logcat.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/drivers/logcat.ts)_
 
 ## `smartthings edge:drivers:package [PROJECTDIRECTORY]`
 
@@ -604,7 +605,7 @@ EXAMPLE
   $ smartthings edge:drivers:package -u driver.zip
 ```
 
-_See code: [src/commands/edge/drivers/package.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/drivers/package.ts)_
+_See code: [src/commands/edge/drivers/package.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/drivers/package.ts)_
 
 ## `smartthings edge:drivers:uninstall [DRIVERID]`
 
@@ -625,7 +626,7 @@ OPTIONS
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
-_See code: [src/commands/edge/drivers/uninstall.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.2/src/commands/edge/drivers/uninstall.ts)_
+_See code: [src/commands/edge/drivers/uninstall.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.4.3/src/commands/edge/drivers/uninstall.ts)_
 <!-- commandsstop -->
 
 # Building

--- a/package-lock.json
+++ b/package-lock.json
@@ -1884,12 +1884,12 @@
 			}
 		},
 		"@smartthings/cli-lib": {
-			"version": "0.0.0-pre.26",
-			"resolved": "https://registry.npmjs.org/@smartthings/cli-lib/-/cli-lib-0.0.0-pre.26.tgz",
-			"integrity": "sha512-pPbIfod+Z21TRm8MHWRApcTlOUr0I1laPHkcgjcc47BfCizAjjadCbYBQSH5mHrpspq22h+rYPiWB3JHGatzAg==",
+			"version": "0.0.0-pre.32",
+			"resolved": "https://registry.npmjs.org/@smartthings/cli-lib/-/cli-lib-0.0.0-pre.32.tgz",
+			"integrity": "sha512-O5VsktsaA07KsF0OoA6Mrtk5jdlkQ/+5JHrMiqPk3e3aZK3CBB/3uk0zBeqxqtHhUz84e1hl34k570qSdOXZkg==",
 			"requires": {
 				"@oclif/errors": "1.3.3",
-				"@smartthings/core-sdk": "^1.9.0",
+				"@smartthings/core-sdk": "^1.10.1",
 				"@types/eventsource": "^1.1.5",
 				"axios": "^0.21.1",
 				"chalk": "^4.1.0",
@@ -1916,6 +1916,19 @@
 						"indent-string": "^4.0.0",
 						"strip-ansi": "^6.0.0",
 						"wrap-ansi": "^7.0.0"
+					}
+				},
+				"@smartthings/core-sdk": {
+					"version": "1.10.1",
+					"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-1.10.1.tgz",
+					"integrity": "sha512-XhCYlf8RoNy5uk3I4198DPMq1nQ4csc/W3nCCj/vl/laW/zhnje9EQ13Z/8qs8fx3+aCtWzcUqvPit/uqD8Tzg==",
+					"requires": {
+						"async-mutex": "^0.2.1",
+						"axios": "^0.21.1",
+						"http-signature": "^1.3.4",
+						"qs": "^6.9.3",
+						"sshpk": "^1.16.1",
+						"underscore": "^1.10.2"
 					}
 				},
 				"ansi-styles": {
@@ -1978,9 +1991,9 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"inquirer": {
-					"version": "8.1.2",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.2.tgz",
-					"integrity": "sha512-DHLKJwLPNgkfwNmsuEUKSejJFbkv0FMO9SMiQbjI3n5NQuCrSIBqP66ggqyz2a6t2qEolKrMjhQ3+W/xXgUQ+Q==",
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+					"integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
 					"requires": {
 						"ansi-escapes": "^4.2.1",
 						"chalk": "^4.1.1",
@@ -1990,7 +2003,7 @@
 						"figures": "^3.0.0",
 						"lodash": "^4.17.21",
 						"mute-stream": "0.0.8",
-						"ora": "^5.3.0",
+						"ora": "^5.4.1",
 						"run-async": "^2.4.0",
 						"rxjs": "^7.2.0",
 						"string-width": "^4.1.0",
@@ -2084,9 +2097,9 @@
 			"dev": true
 		},
 		"@types/eventsource": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.6.tgz",
-			"integrity": "sha512-y4xcLJ+lcoZ6mN9ndSdKOWg24Nj5uQc4Z/NRdy3HbiGGt5hfH3RLwAXr6V+RzGzOljAk48a09n6iY4BMNumEng=="
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.7.tgz",
+			"integrity": "sha512-ac36T7U0sz2+vrYT3oTU4x0dnNOZcI2rmUFfSA8pIpXKYPNGHMZs8KzJ+WuF6aPRQu8RAvGgnoLUWMXhC7Widw=="
 		},
 		"@types/glob": {
 			"version": "7.1.4",
@@ -3004,9 +3017,9 @@
 			}
 		},
 		"cli-spinners": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
-			"integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q=="
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+			"integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g=="
 		},
 		"cli-table": {
 			"version": "0.3.6",
@@ -11998,9 +12011,9 @@
 			}
 		},
 		"rxjs": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
-			"integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+			"integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
 			"requires": {
 				"tslib": "~2.1.0"
 			},

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"@oclif/config": "^1.17.0",
 		"@oclif/errors": "^1.3.4",
 		"@oclif/plugin-help": "^3.2.2",
-		"@smartthings/cli-lib": "0.0.0-pre.26",
+		"@smartthings/cli-lib": "0.0.0-pre.32",
 		"@smartthings/core-sdk": "^1.8.0",
 		"axios": "^0.21.1",
 		"cli-ux": "^5.5.1",

--- a/src/commands/edge/channels/assign.ts
+++ b/src/commands/edge/channels/assign.ts
@@ -33,7 +33,8 @@ export class ChannelsAssignCommand extends EdgeCommand {
 		const { args, argv, flags } = this.parse(ChannelsAssignCommand)
 		await super.setup(args, argv, flags)
 
-		const channelId = await chooseChannel(this, 'Select a channel for the driver.', flags.channel)
+		const channelId = await chooseChannel(this, 'Select a channel for the driver.',
+			flags.channel, this.defaultChannelId)
 		const driverId = await chooseDriver(this, 'Select a driver to assign.', args.driverId)
 
 		// If the version wasn't specified, grab it from the driver.

--- a/src/commands/edge/channels/drivers.ts
+++ b/src/commands/edge/channels/drivers.ts
@@ -31,7 +31,7 @@ export default class ChannelsDriversCommand extends EdgeCommand {
 		}
 
 		const channelId = await chooseChannel(this, 'Select a channel.', args.idOrIndex,
-			{ allowIndex: true, includeReadOnly: true })
+			this.defaultChannelId, { allowIndex: true, includeReadOnly: true })
 
 		await outputList(this, config, () => listAssignedDriversWithNames(this.edgeClient, channelId))
 	}

--- a/src/commands/edge/channels/enroll.ts
+++ b/src/commands/edge/channels/enroll.ts
@@ -27,9 +27,9 @@ export class ChannelsEnrollCommand extends EdgeCommand {
 		const { args, argv, flags } = this.parse(ChannelsEnrollCommand)
 		await super.setup(args, argv, flags)
 
-		const channelId = await chooseChannel(this, 'Select a channel.', flags.channel,
+		const channelId = await chooseChannel(this, 'Select a channel.', flags.channel, undefined,
 			{ includeReadOnly: true })
-		const hubId = await chooseHub(this, 'Select a hub.', args.hubId)
+		const hubId = await chooseHub(this, 'Select a hub.', args.hubId, this.defaultHubId)
 
 		await this.edgeClient.channels.enrollHub(channelId, hubId)
 

--- a/src/commands/edge/channels/enrollments.ts
+++ b/src/commands/edge/channels/enrollments.ts
@@ -27,7 +27,8 @@ export default class ChannelsEnrollmentsCommand extends EdgeCommand {
 			listTableFieldDefinitions: ['channelId', 'name', 'description', 'createdDate', 'lastModifiedDate', 'subscriptionUrl'],
 		}
 
-		const hubId = await chooseHub(this, 'Select a hub.', args.idOrIndex, { allowIndex: true })
+		const hubId = await chooseHub(this, 'Select a hub.', args.idOrIndex, this.defaultHubId,
+			{ allowIndex: true })
 
 		await outputList(this, config, () => this.edgeClient.hubs.enrolledChannels(hubId))
 	}

--- a/src/commands/edge/channels/invites/create.ts
+++ b/src/commands/edge/channels/invites/create.ts
@@ -1,3 +1,4 @@
+import { flags } from '@oclif/command'
 import inquirer from 'inquirer'
 
 import { inputAndOutputItem, userInputProcessor } from '@smartthings/cli-lib'
@@ -15,6 +16,11 @@ export default class ChannelsInvitesCreateCommand extends EdgeCommand {
 	static description = 'create an invitation'
 
 	static flags = {
+		channel: flags.string({
+			char: 'C',
+			description: 'channel id',
+			exclusive: ['input'],
+		}),
 		...EdgeCommand.flags,
 		...inputAndOutputItem.flags,
 	}
@@ -35,7 +41,8 @@ export default class ChannelsInvitesCreateCommand extends EdgeCommand {
 	}
 
 	async getInputFromUser(): Promise<CreateInvitation> {
-		const channelId = await chooseChannel(this, 'Choose a channel:', undefined, {})
+		const channelId = await chooseChannel(this, 'Choose a channel:', this.flags.channel,
+			this.defaultChannelId)
 
 		const name = (await inquirer.prompt({
 			type: 'input',

--- a/src/commands/edge/channels/invites/delete.ts
+++ b/src/commands/edge/channels/invites/delete.ts
@@ -32,7 +32,8 @@ export default class ChannelsInvitesDeleteCommand extends EdgeCommand {
 		await super.setup(args, argv, flags)
 
 		const channelId = await chooseChannel(this,
-			'Which channel is the invite you want to delete for?', flags.channel)
+			'Which channel is the invite you want to delete for?',
+			flags.channel, this.defaultChannelId)
 
 		const id = await chooseInvite(this, 'Choose an invitation to delete.', channelId, args.id)
 		await this.edgeClient.invites.delete(id)

--- a/src/commands/edge/channels/unassign.ts
+++ b/src/commands/edge/channels/unassign.ts
@@ -63,7 +63,8 @@ export class ChannelsUnassignCommand extends EdgeCommand {
 		const { args, argv, flags } = this.parse(ChannelsUnassignCommand)
 		await super.setup(args, argv, flags)
 
-		const channelId = await chooseChannel(this, 'Select a channel for the driver.', flags.channel)
+		const channelId = await chooseChannel(this, 'Select a channel for the driver.',
+			flags.channel, this.defaultChannelId)
 		const driverId = await chooseAssignedDriver(this, 'Select a driver to remove from channel.',
 			channelId, args.driverId)
 

--- a/src/commands/edge/channels/unenroll.ts
+++ b/src/commands/edge/channels/unenroll.ts
@@ -27,9 +27,9 @@ export class ChannelsUnenrollCommand extends EdgeCommand {
 		const { args, argv, flags } = this.parse(ChannelsUnenrollCommand)
 		await super.setup(args, argv, flags)
 
-		const channelId = await chooseChannel(this, 'Select a channel.', flags.channel,
+		const channelId = await chooseChannel(this, 'Select a channel.', flags.channel, undefined,
 			{ includeReadOnly: true })
-		const hubId = await chooseHub(this, 'Select a hub.', args.hubId)
+		const hubId = await chooseHub(this, 'Select a hub.', args.hubId, this.defaultHubId)
 
 		await this.edgeClient.channels.unenrollHub(channelId, hubId)
 

--- a/src/commands/edge/channels/update.ts
+++ b/src/commands/edge/channels/update.ts
@@ -23,7 +23,8 @@ export default class ChannelsUpdateCommand extends EdgeCommand {
 		const { args, argv, flags } = this.parse(ChannelsUpdateCommand)
 		await super.setup(args, argv, flags)
 
-		const id = await chooseChannel(this, 'Choose a channel to patch.', args.id)
+		const id = await chooseChannel(this, 'Choose a channel to patch.', args.id,
+			this.defaultChannelId)
 		await inputAndOutputItem<ChannelUpdate, Channel>(this, { tableFieldDefinitions },
 			(_, channelMods) => this.edgeClient.channels.update(id, channelMods))
 	}

--- a/src/commands/edge/drivers/install.ts
+++ b/src/commands/edge/drivers/install.ts
@@ -39,15 +39,18 @@ export default class DriversInstallCommand extends EdgeCommand {
 			primaryKeyName: 'channelId',
 			sortKeyName: 'name',
 		}
-		const listChannels = (): Promise<EnrolledChannel[]> => this.edgeClient.hubs.enrolledChannels(hubId)
-		return selectFromList(this, config, undefined, listChannels, 'Select a channel to install the driver from.')
+		const listChannels = (): Promise<EnrolledChannel[]> =>
+			this.edgeClient.hubs.enrolledChannels(hubId)
+		return selectFromList(this, config, this.defaultChannelId, listChannels,
+			'Select a channel to install the driver from.')
 	}
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(DriversInstallCommand)
 		await super.setup(args, argv, flags)
 
-		const hubId = await chooseHub(this, 'Select a hub to install to.', flags.hub)
+		const hubId = await chooseHub(this, 'Select a hub to install to.', flags.hub,
+			this.defaultHubId)
 		const channelId = flags.channel ?? await this.chooseChannelFromEnrollments(hubId)
 		const driverId = await chooseDriverFromChannel(this, channelId, args.driverId)
 		await this.edgeClient.hubs.installDriver(driverId, hubId, channelId)

--- a/src/commands/edge/drivers/installed.ts
+++ b/src/commands/edge/drivers/installed.ts
@@ -30,11 +30,14 @@ export default class DriversInstalledCommand extends EdgeCommand {
 		const config = {
 			primaryKeyName: 'channelId',
 			sortKeyName: 'name',
-			tableFieldDefinitions: ['driverId', 'name', 'description', 'version', 'channelId', 'developer', 'vendorSummaryInformation'],
-			listTableFieldDefinitions: ['driverId', 'name', 'description', 'version', 'channelId', 'developer', 'vendorSummaryInformation'],
+			tableFieldDefinitions: ['driverId', 'name', 'description', 'version', 'channelId',
+				'developer', 'vendorSummaryInformation'],
+			listTableFieldDefinitions: ['driverId', 'name', 'description', 'version', 'channelId',
+				'developer', 'vendorSummaryInformation'],
 		}
 
-		const hubId = await chooseHub(this, 'Select a hub.', flags.hub, { allowIndex: true })
+		const hubId = await chooseHub(this, 'Select a hub.', flags.hub, this.defaultHubId,
+			{ allowIndex: true })
 
 		await outputListing(this, config, args.idOrIndex,
 			() => this.edgeClient.hubs.listInstalled(hubId),

--- a/src/commands/edge/drivers/package.ts
+++ b/src/commands/edge/drivers/package.ts
@@ -88,11 +88,13 @@ $ smartthings edge:drivers:package -u driver.zip`]
 			if (doAssign) {
 				const driverId = driver.driverId
 				const version = driver.version
-				const channelId = await chooseChannel(this, 'Select a channel for the driver.', flags.channel)
+				const channelId = await chooseChannel(this, 'Select a channel for the driver.',
+					flags.channel, this.defaultChannelId)
 				await this.edgeClient.channels.assignDriver(channelId, driverId, version)
 
 				if (doInstall) {
-					const hubId = await chooseHub(this, 'Select a hub to install to.', flags.hub)
+					const hubId = await chooseHub(this, 'Select a hub to install to.', flags.hub,
+						this.defaultChannelId)
 					await this.edgeClient.hubs.installDriver(driverId, hubId, channelId)
 				}
 			}

--- a/src/commands/edge/drivers/uninstall.ts
+++ b/src/commands/edge/drivers/uninstall.ts
@@ -22,7 +22,8 @@ export default class DriversUninstallCommand extends EdgeCommand {
 		description: 'id of driver to uninstall',
 	}]
 
-	private async chooseInstalledDriver(hubId: string, promptMessage: string, commandLineDriverId?: string): Promise<string> {
+	private async chooseInstalledDriver(hubId: string, promptMessage: string,
+			commandLineDriverId?: string): Promise<string> {
 		const config = {
 			itemName: 'driver',
 			primaryKeyName: 'driverId',
@@ -38,8 +39,10 @@ export default class DriversUninstallCommand extends EdgeCommand {
 		const { args, argv, flags } = this.parse(DriversUninstallCommand)
 		await super.setup(args, argv, flags)
 
-		const hubId = await chooseHub(this, 'Select a hub to uninstall from.', flags.hub)
-		const driverId = await this.chooseInstalledDriver(hubId, 'Select a driver to uninstall.', args.driverId)
+		const hubId = await chooseHub(this, 'Select a hub to uninstall from.', flags.hub,
+			this.defaultHubId)
+		const driverId = await this.chooseInstalledDriver(hubId, 'Select a driver to uninstall.',
+			args.driverId)
 		await this.edgeClient.hubs.uninstallDriver(driverId, hubId)
 		this.log(`driver ${driverId} uninstalled from hub ${hubId}`)
 	}

--- a/src/lib/commands/channels-util.ts
+++ b/src/lib/commands/channels-util.ts
@@ -14,7 +14,8 @@ export const chooseChannelOptionsWithDefaults = (options?: Partial<ChooseChannel
 })
 
 export async function chooseChannel(command: EdgeCommand, promptMessage: string,
-		channelFromArg?: string, options?: Partial<ChooseChannelOptions>): Promise<string> {
+		channelFromArg?: string, defaultChannelId?: string,
+		options?: Partial<ChooseChannelOptions>): Promise<string> {
 	const opts = chooseChannelOptionsWithDefaults(options)
 	const config = {
 		itemName: 'channel',
@@ -24,8 +25,12 @@ export async function chooseChannel(command: EdgeCommand, promptMessage: string,
 	const listChannels = (): Promise<Channel[]> => command.edgeClient.channels.list({
 		includeReadOnly: opts.includeReadOnly,
 	})
-	const preselectedId = opts.allowIndex
-		? await stringTranslateToId(config, channelFromArg, listChannels)
-		: channelFromArg
+
+	const preselectedId = channelFromArg
+		? (opts.allowIndex
+			? await stringTranslateToId(config, channelFromArg, listChannels)
+			: channelFromArg)
+		: defaultChannelId
+
 	return selectFromList(command, config, preselectedId, listChannels, promptMessage)
 }

--- a/src/lib/commands/drivers-util.ts
+++ b/src/lib/commands/drivers-util.ts
@@ -24,7 +24,8 @@ export async function chooseDriver(command: EdgeCommand, promptMessage: string, 
 	return selectFromList(command, config, preselectedId, listDrivers, promptMessage)
 }
 
-export const chooseHub = async (command: APICommand, promptMessage: string, commandLineHubId?: string,
+export const chooseHub = async (command: APICommand, promptMessage: string,
+		commandLineHubId: string | undefined, defaultHubId: string | undefined,
 		options?: Partial<ChooseOptions>): Promise<string> => {
 	const opts = chooseOptionsWithDefaults(options)
 	const config = {
@@ -35,9 +36,13 @@ export const chooseHub = async (command: APICommand, promptMessage: string, comm
 	}
 	const listDrivers = (): Promise<Device[]> => command.client.devices.list(
 		{ capability: 'bridge', type: DeviceIntegrationType.HUB })
-	const preselectedId = opts.allowIndex
-		? await stringTranslateToId(config, commandLineHubId, listDrivers)
-		: commandLineHubId
+
+	const preselectedId = commandLineHubId
+		? (opts.allowIndex
+			? await stringTranslateToId(config, commandLineHubId, listDrivers)
+			: commandLineHubId)
+		: defaultHubId
+
 	return selectFromList(command, config, preselectedId, listDrivers, promptMessage)
 }
 

--- a/src/lib/edge-command.ts
+++ b/src/lib/edge-command.ts
@@ -17,6 +17,9 @@ export abstract class EdgeCommand extends APICommand {
 		throw new Error('EdgeCommand not initialized properly')
 	}
 
+	defaultChannelId?: string
+	defaultHubId?: string
+
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	async setup(args: { [name: string]: any }, argv: string[], flags: { [name: string]: any }): Promise<void> {
 		await super.setup(args, argv, flags)
@@ -28,5 +31,8 @@ export abstract class EdgeCommand extends APICommand {
 		const logger = logManager.getLogger('rest-client')
 		this._edgeClient = new EdgeClient(authenticator,
 			{ urlProvider: this.clientIdProvider, logger })
+
+		this.defaultChannelId = this.stringConfigValue('defaultChannel')
+		this.defaultHubId = this.stringConfigValue('defaultHub')
 	}
 }

--- a/test/unit/commands/edge/channels/drivers.test.ts
+++ b/test/unit/commands/edge/channels/drivers.test.ts
@@ -40,7 +40,7 @@ describe('ChannelsDriversCommand', () => {
 
 		expect(chooseChannelMock).toHaveBeenCalledTimes(1)
 		expect(chooseChannelMock).toHaveBeenCalledWith(expect.any(ChannelsDriversCommand),
-			'Select a channel.', undefined,
+			'Select a channel.', undefined, undefined,
 			expect.objectContaining({ allowIndex: true, includeReadOnly: true }))
 		expect(outputListMock).toHaveBeenCalledTimes(1)
 		expect(outputListMock).toHaveBeenCalledWith(expect.any(ChannelsDriversCommand),
@@ -56,7 +56,7 @@ describe('ChannelsDriversCommand', () => {
 
 		expect(chooseChannelMock).toHaveBeenCalledTimes(1)
 		expect(chooseChannelMock).toHaveBeenCalledWith(expect.any(ChannelsDriversCommand),
-			'Select a channel.', 'id-or-index',
+			'Select a channel.', 'id-or-index', undefined,
 			expect.objectContaining({ allowIndex: true, includeReadOnly: true }))
 		expect(outputListMock).toHaveBeenCalledTimes(1)
 		expect(outputListMock).toHaveBeenCalledWith(expect.any(ChannelsDriversCommand),
@@ -72,7 +72,7 @@ describe('ChannelsDriversCommand', () => {
 
 		expect(chooseChannelMock).toHaveBeenCalledTimes(1)
 		expect(chooseChannelMock).toHaveBeenCalledWith(expect.any(ChannelsDriversCommand),
-			'Select a channel.', undefined,
+			'Select a channel.', undefined, undefined,
 			expect.objectContaining({ allowIndex: true, includeReadOnly: true }))
 		expect(outputListMock).toHaveBeenCalledTimes(1)
 		expect(outputListMock).toHaveBeenCalledWith(expect.any(ChannelsDriversCommand),

--- a/test/unit/commands/edge/drivers/install.test.ts
+++ b/test/unit/commands/edge/drivers/install.test.ts
@@ -47,7 +47,7 @@ describe('DriversInstallCommand', () => {
 
 		expect(chooseHubMock).toHaveBeenCalledTimes(1)
 		expect(chooseHubMock).toHaveBeenCalledWith(expect.any(DriversInstallCommand),
-			'Select a hub to install to.', undefined)
+			'Select a hub to install to.', undefined, undefined)
 		expect(selectFromListMock).toHaveBeenCalledTimes(1)
 		expect(selectFromListMock).toHaveBeenCalledWith(expect.any(DriversInstallCommand),
 			expect.objectContaining({ primaryKeyName: 'channelId' }), undefined,
@@ -76,7 +76,7 @@ describe('DriversInstallCommand', () => {
 
 		expect(chooseHubMock).toHaveBeenCalledTimes(1)
 		expect(chooseHubMock).toHaveBeenCalledWith(expect.any(DriversInstallCommand),
-			'Select a hub to install to.', 'command-line-hub-id')
+			'Select a hub to install to.', 'command-line-hub-id', undefined)
 	})
 
 	it('uses channel from command line if specified', async () => {

--- a/test/unit/commands/edge/drivers/package.test.ts
+++ b/test/unit/commands/edge/drivers/package.test.ts
@@ -203,7 +203,8 @@ describe('PackageCommand', () => {
 			.toHaveBeenCalledWith(expect.any(PackageCommand), expect.anything(), expect.any(Function))
 		expect(chooseChannelMock).toHaveBeenCalledTimes(1)
 		expect(chooseChannelMock)
-			.toHaveBeenCalledWith(expect.any(PackageCommand), 'Select a channel for the driver.', undefined)
+			.toHaveBeenCalledWith(expect.any(PackageCommand), 'Select a channel for the driver.',
+				undefined, undefined)
 		expect(assignDriverSpy).toHaveBeenCalledTimes(1)
 		expect(assignDriverSpy)
 			.toHaveBeenCalledWith('channel id', 'driver id', 'driver version')
@@ -226,7 +227,8 @@ describe('PackageCommand', () => {
 			.toHaveBeenCalledWith(expect.any(PackageCommand), expect.anything(), expect.any(Function))
 		expect(chooseChannelMock).toHaveBeenCalledTimes(1)
 		expect(chooseChannelMock)
-			.toHaveBeenCalledWith(expect.any(PackageCommand), 'Select a channel for the driver.', 'channel id arg')
+			.toHaveBeenCalledWith(expect.any(PackageCommand), 'Select a channel for the driver.',
+				'channel id arg', undefined)
 		expect(assignDriverSpy).toHaveBeenCalledTimes(1)
 		expect(assignDriverSpy)
 			.toHaveBeenCalledWith('channel id', 'driver id', 'driver version')
@@ -249,7 +251,8 @@ describe('PackageCommand', () => {
 			.toHaveBeenCalledWith(expect.any(PackageCommand), expect.anything(), expect.any(Function))
 		expect(chooseChannelMock).toHaveBeenCalledTimes(1)
 		expect(chooseChannelMock)
-			.toHaveBeenCalledWith(expect.any(PackageCommand), 'Select a channel for the driver.', undefined)
+			.toHaveBeenCalledWith(expect.any(PackageCommand), 'Select a channel for the driver.',
+				undefined, undefined)
 		expect(assignDriverSpy).toHaveBeenCalledTimes(1)
 		expect(assignDriverSpy)
 			.toHaveBeenCalledWith('channel id', 'driver id', 'driver version')
@@ -257,7 +260,8 @@ describe('PackageCommand', () => {
 		expect(uploadSpy).toHaveBeenCalledWith(zipContents)
 		expect(chooseHubSpy).toHaveBeenCalledTimes(1)
 		expect(chooseHubSpy)
-			.toHaveBeenCalledWith(expect.any(PackageCommand), 'Select a hub to install to.', undefined)
+			.toHaveBeenCalledWith(expect.any(PackageCommand), 'Select a hub to install to.',
+				undefined, undefined)
 		expect(installDriverSpy).toHaveBeenCalledTimes(1)
 		expect(installDriverSpy).toHaveBeenCalledWith('driver id', 'hub id', 'channel id')
 	})
@@ -275,7 +279,8 @@ describe('PackageCommand', () => {
 			.toHaveBeenCalledWith(expect.any(PackageCommand), expect.anything(), expect.any(Function))
 		expect(chooseChannelMock).toHaveBeenCalledTimes(1)
 		expect(chooseChannelMock)
-			.toHaveBeenCalledWith(expect.any(PackageCommand), 'Select a channel for the driver.', undefined)
+			.toHaveBeenCalledWith(expect.any(PackageCommand), 'Select a channel for the driver.',
+				undefined, undefined)
 		expect(assignDriverSpy).toHaveBeenCalledTimes(1)
 		expect(assignDriverSpy)
 			.toHaveBeenCalledWith('channel id', 'driver id', 'driver version')
@@ -283,7 +288,8 @@ describe('PackageCommand', () => {
 		expect(uploadSpy).toHaveBeenCalledWith(zipContents)
 		expect(chooseHubSpy).toHaveBeenCalledTimes(1)
 		expect(chooseHubSpy)
-			.toHaveBeenCalledWith(expect.any(PackageCommand), 'Select a hub to install to.', 'hub id arg')
+			.toHaveBeenCalledWith(expect.any(PackageCommand), 'Select a hub to install to.',
+				'hub id arg', undefined)
 		expect(installDriverSpy).toHaveBeenCalledTimes(1)
 		expect(installDriverSpy).toHaveBeenCalledWith('driver id', 'hub id', 'channel id')
 	})

--- a/test/unit/lib/commands/channels-util.test.ts
+++ b/test/unit/lib/commands/channels-util.test.ts
@@ -60,11 +60,30 @@ describe('channels-util', () => {
 		const stringTranslateToIdMock = stringTranslateToId as unknown as
 			jest.Mock<Promise<string | undefined>, [Sorting & Naming, string | undefined, ListDataFunction<Channel>]>
 
-		it('presents user with list of channels', async () => {
-			chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce({ allowIndex: false } as ChooseChannelOptions)
+		it('uses default channel if specified', async () => {
+			chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce(
+				{ allowIndex: false } as ChooseChannelOptions)
 			selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
 
-			expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id')).toBe('chosen-channel-id')
+			expect(await chooseChannel(command, 'prompt message', undefined, 'default-channel-id'))
+				.toBe('chosen-channel-id')
+
+			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
+			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith(undefined)
+			expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
+			expect(selectFromListMock).toHaveBeenCalledTimes(1)
+			expect(selectFromListMock).toHaveBeenCalledWith(command,
+				expect.objectContaining({ primaryKeyName: 'channelId', sortKeyName: 'name' }),
+				'default-channel-id', expect.any(Function), 'prompt message')
+		})
+
+		it('prefers command line over default', async () => {
+			chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce(
+				{ allowIndex: false } as ChooseChannelOptions)
+			selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
+
+			expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id',
+				'default-channel-id')).toBe('chosen-channel-id')
 
 			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
 			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith(undefined)
@@ -82,7 +101,7 @@ describe('channels-util', () => {
 			selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
 
 			expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id',
-				{ allowIndex: true })).toBe('chosen-channel-id')
+				'default-channel-id', { allowIndex: true })).toBe('chosen-channel-id')
 
 			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
 			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith({ allowIndex: true })
@@ -101,8 +120,8 @@ describe('channels-util', () => {
 				{ allowIndex: false, includeReadOnly: false } as ChooseChannelOptions)
 			selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
 
-			expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id'))
-				.toBe('chosen-channel-id')
+			expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id',
+				'default-channel-id')).toBe('chosen-channel-id')
 
 			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
 			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith(undefined)
@@ -128,8 +147,8 @@ describe('channels-util', () => {
 				{ allowIndex: false, includeReadOnly: true } as ChooseChannelOptions)
 			selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
 
-			expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id'))
-				.toBe('chosen-channel-id')
+			expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id',
+				'default-channel-id')) .toBe('chosen-channel-id')
 
 			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
 			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith(undefined)

--- a/test/unit/lib/commands/drivers-util.test.ts
+++ b/test/unit/lib/commands/drivers-util.test.ts
@@ -109,11 +109,28 @@ describe('drivers-util', () => {
 		const stringTranslateToIdMock = stringTranslateToId as unknown as
 			jest.Mock<Promise<string | undefined>, [Sorting & Naming, string | undefined, ListDataFunction<Device>]>
 
-		it('presents user with list of hubs', async () => {
+		it('uses default hub if specified', async () => {
 			chooseOptionsWithDefaultsMock.mockReturnValueOnce({ allowIndex: false } as ChooseOptions)
 			selectFromListMock.mockImplementation(async () => 'chosen-hub-id')
 
-			expect(await chooseHub(command, 'prompt message', 'command-line-hub-id')).toBe('chosen-hub-id')
+			expect(await chooseHub(command, 'prompt message', undefined,
+				'default-hub-id')).toBe('chosen-hub-id')
+
+			expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledTimes(1)
+			expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledWith(undefined)
+			expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
+			expect(selectFromListMock).toHaveBeenCalledTimes(1)
+			expect(selectFromListMock).toHaveBeenCalledWith(command,
+				expect.objectContaining({ primaryKeyName: 'deviceId', sortKeyName: 'name' }),
+				'default-hub-id', expect.any(Function), 'prompt message')
+		})
+
+		it('prefers command line over default', async () => {
+			chooseOptionsWithDefaultsMock.mockReturnValueOnce({ allowIndex: false } as ChooseOptions)
+			selectFromListMock.mockImplementation(async () => 'chosen-hub-id')
+
+			expect(await chooseHub(command, 'prompt message', 'command-line-hub-id',
+				'default-hub-id')).toBe('chosen-hub-id')
 
 			expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledTimes(1)
 			expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledWith(undefined)
@@ -130,7 +147,7 @@ describe('drivers-util', () => {
 			selectFromListMock.mockImplementation(async () => 'chosen-hub-id')
 
 			expect(await chooseHub(command, 'prompt message', 'command-line-hub-id',
-				{ allowIndex: true })).toBe('chosen-hub-id')
+				'default-hub-id', { allowIndex: true })).toBe('chosen-hub-id')
 
 			expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledTimes(1)
 			expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledWith({ allowIndex: true })
@@ -148,8 +165,8 @@ describe('drivers-util', () => {
 			chooseOptionsWithDefaultsMock.mockReturnValueOnce({ allowIndex: false } as ChooseOptions)
 			selectFromListMock.mockImplementation(async () => 'chosen-hub-id')
 
-			expect(await chooseHub(command, 'prompt message', 'command-line-hub-id'))
-				.toBe('chosen-hub-id')
+			expect(await chooseHub(command, 'prompt message', 'command-line-hub-id',
+				'default-hub-id')).toBe('chosen-hub-id')
 
 			expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledTimes(1)
 			expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledWith(undefined)


### PR DESCRIPTION
<!-- Describe your pull request. -->

Added `defaultChannel` and `defaultHub` configuration options which allow the user to leave these out of most commands that use a channel or hub. Commands that do NOT use the default are:

* `edge:channels:delete` - In the future we should update this command to remove the default if the default is the one being deleted but we do not plan to allow this command to delete a channel without specifying it explicitly.
* `edge:channels:invites` - This command lists invites for all channels by default. We plan to keep this behavior.
* `edge:channels` - This command lists channels the user owns by default and we plan to keep this behavior.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [x] I have added tests to cover my changes
