### PR TITLE
fix: don't use bridge capability when searching for hubs

### DIFF
--- a/src/lib/commands/drivers-util.ts
+++ b/src/lib/commands/drivers-util.ts
@@ -61,7 +61,7 @@ export const chooseHub = async (command: APICommand, promptMessage: string,
 	}
 
 	const listHubs = async (): Promise<Device[]> => {
-		const hubs = await command.client.devices.list({ capability: 'bridge', type: DeviceIntegrationType.HUB })
+		const hubs = await command.client.devices.list({ type: DeviceIntegrationType.HUB })
 		const locationIds = new Set<string>()
 		hubs.forEach(hub => {
 			if (hub.locationId !== undefined) {

--- a/test/unit/lib/commands/drivers-util.test.ts
+++ b/test/unit/lib/commands/drivers-util.test.ts
@@ -260,8 +260,7 @@ describe('drivers-util', () => {
 			expect(await listFunction()).toStrictEqual(list)
 
 			expect(listDevicesMock).toHaveBeenCalledTimes(1)
-			expect(listDevicesMock).toHaveBeenCalledWith(
-				{ capability: 'bridge', type: DeviceIntegrationType.HUB })
+			expect(listDevicesMock).toHaveBeenCalledWith({ type: DeviceIntegrationType.HUB })
 		})
 
 		test('list function checks hub locations for ownership', async () => {


### PR DESCRIPTION
<!-- Describe your pull request. -->

Just removed `bridge` capability as a limiting factor when searching for hubs. This is not necessary and the `bridge` capability is deprecated.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
