### PR TITLE
List channels cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ list all channels owned by you or retrieve a single channel
 ```
 USAGE
   $ smartthings edge:channels [IDORINDEX] [-h] [-p <value>] [-t <value>] [--language <value>] [-O <value>] [-j]
-    [-y] [-o <value>] [-A] [-I] [--subscriber-id <value> --subscriber-type HUB]
+    [-y] [-o <value>] [-I | -A] [--subscriber-id <value> --subscriber-type HUB]
 
 ARGUMENTS
   IDORINDEX  the channel id or number in list
@@ -94,7 +94,7 @@ EXAMPLES
   $ smartthings edge:channels --subscriber-type HUB --subscriber-id <hub-id>
 ```
 
-_See code: [src/commands/edge/channels.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels.ts)_
+_See code: [src/commands/edge/channels.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels.ts)_
 
 ## `smartthings edge:channels:assign [DRIVERID] [VERSION]`
 
@@ -124,7 +124,7 @@ ALIASES
   $ smartthings edge:drivers:publish
 ```
 
-_See code: [src/commands/edge/channels/assign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/assign.ts)_
+_See code: [src/commands/edge/channels/assign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/assign.ts)_
 
 ## `smartthings edge:channels:assignments [IDORINDEX]`
 
@@ -180,7 +180,7 @@ DESCRIPTION
   create a channel
 ```
 
-_See code: [src/commands/edge/channels/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/create.ts)_
+_See code: [src/commands/edge/channels/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/create.ts)_
 
 ## `smartthings edge:channels:delete [ID]`
 
@@ -204,7 +204,7 @@ DESCRIPTION
   delete a channel
 ```
 
-_See code: [src/commands/edge/channels/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/delete.ts)_
+_See code: [src/commands/edge/channels/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/delete.ts)_
 
 ## `smartthings edge:channels:drivers [IDORINDEX]`
 
@@ -235,7 +235,7 @@ ALIASES
   $ smartthings edge:channels:assignments
 ```
 
-_See code: [src/commands/edge/channels/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/drivers.ts)_
+_See code: [src/commands/edge/channels/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/drivers.ts)_
 
 ## `smartthings edge:channels:enroll [HUBID]`
 
@@ -261,7 +261,7 @@ DESCRIPTION
   enroll a hub in a channel
 ```
 
-_See code: [src/commands/edge/channels/enroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/enroll.ts)_
+_See code: [src/commands/edge/channels/enroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/enroll.ts)_
 
 ## `smartthings edge:channels:enrollments [IDORINDEX]`
 
@@ -289,7 +289,7 @@ DESCRIPTION
   list all channels a given hub is enrolled in
 ```
 
-_See code: [src/commands/edge/channels/enrollments.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/enrollments.ts)_
+_See code: [src/commands/edge/channels/enrollments.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/enrollments.ts)_
 
 ## `smartthings edge:channels:invitations [IDORINDEX]`
 
@@ -481,7 +481,7 @@ EXAMPLES
   $ smartthings edge:channels:invites <invite id>      # list details about the invite with id <invite id>
 ```
 
-_See code: [src/commands/edge/channels/invites.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/invites.ts)_
+_See code: [src/commands/edge/channels/invites.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/invites.ts)_
 
 ## `smartthings edge:channels:invites:accept ID`
 
@@ -508,7 +508,7 @@ ALIASES
   $ smartthings edge:channels:invitations:accept
 ```
 
-_See code: [src/commands/edge/channels/invites/accept.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/invites/accept.ts)_
+_See code: [src/commands/edge/channels/invites/accept.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/invites/accept.ts)_
 
 ## `smartthings edge:channels:invites:create`
 
@@ -539,7 +539,7 @@ ALIASES
   $ smartthings edge:channels:invitations:create
 ```
 
-_See code: [src/commands/edge/channels/invites/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/invites/create.ts)_
+_See code: [src/commands/edge/channels/invites/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/invites/create.ts)_
 
 ## `smartthings edge:channels:invites:delete [ID]`
 
@@ -570,7 +570,7 @@ ALIASES
   $ smartthings edge:channels:invites:revoke
 ```
 
-_See code: [src/commands/edge/channels/invites/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/invites/delete.ts)_
+_See code: [src/commands/edge/channels/invites/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/invites/delete.ts)_
 
 ## `smartthings edge:channels:invites:revoke [ID]`
 
@@ -641,7 +641,7 @@ EXAMPLES
       699c7308-8c72-4363-9571-880d0f5cc725
 ```
 
-_See code: [src/commands/edge/channels/metainfo.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/metainfo.ts)_
+_See code: [src/commands/edge/channels/metainfo.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/metainfo.ts)_
 
 ## `smartthings edge:channels:unassign [DRIVERID]`
 
@@ -670,7 +670,7 @@ ALIASES
   $ smartthings edge:drivers:unpublish
 ```
 
-_See code: [src/commands/edge/channels/unassign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/unassign.ts)_
+_See code: [src/commands/edge/channels/unassign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/unassign.ts)_
 
 ## `smartthings edge:channels:unenroll [HUBID]`
 
@@ -696,7 +696,7 @@ DESCRIPTION
   unenroll a hub from a channel
 ```
 
-_See code: [src/commands/edge/channels/unenroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/unenroll.ts)_
+_See code: [src/commands/edge/channels/unenroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/unenroll.ts)_
 
 ## `smartthings edge:channels:update [ID]`
 
@@ -726,7 +726,7 @@ DESCRIPTION
   update a channel
 ```
 
-_See code: [src/commands/edge/channels/update.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/channels/update.ts)_
+_See code: [src/commands/edge/channels/update.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/channels/update.ts)_
 
 ## `smartthings edge:drivers [IDORINDEX]`
 
@@ -775,7 +775,7 @@ EXAMPLES
   $ smartthings edge:drivers 699c7308-8c72-4363-9571-880d0f5cc725 --version 2021-10-25T00:48:23.295969
 ```
 
-_See code: [src/commands/edge/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/drivers.ts)_
+_See code: [src/commands/edge/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/drivers.ts)_
 
 ## `smartthings edge:drivers:delete [ID]`
 
@@ -799,7 +799,7 @@ DESCRIPTION
   delete an edge driver
 ```
 
-_See code: [src/commands/edge/drivers/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/drivers/delete.ts)_
+_See code: [src/commands/edge/drivers/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/drivers/delete.ts)_
 
 ## `smartthings edge:drivers:install [DRIVERID]`
 
@@ -833,7 +833,7 @@ EXAMPLES
   $ smartthings edge:drivers:install -H <hub-id> -C <channel-id> <driver-id> # install a driver from a channel on an enrolled hub
 ```
 
-_See code: [src/commands/edge/drivers/install.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/drivers/install.ts)_
+_See code: [src/commands/edge/drivers/install.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/drivers/install.ts)_
 
 ## `smartthings edge:drivers:installed [IDORINDEX]`
 
@@ -862,7 +862,7 @@ DESCRIPTION
   list all drivers installed on a given hub
 ```
 
-_See code: [src/commands/edge/drivers/installed.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/drivers/installed.ts)_
+_See code: [src/commands/edge/drivers/installed.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/drivers/installed.ts)_
 
 ## `smartthings edge:drivers:logcat [DRIVERID]`
 
@@ -889,7 +889,7 @@ DESCRIPTION
   stream logs from installed drivers
 ```
 
-_See code: [src/commands/edge/drivers/logcat.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/drivers/logcat.ts)_
+_See code: [src/commands/edge/drivers/logcat.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/drivers/logcat.ts)_
 
 ## `smartthings edge:drivers:package [PROJECTDIRECTORY]`
 
@@ -943,7 +943,7 @@ EXAMPLES
     $ smartthings edge:drivers:package -u driver.zip
 ```
 
-_See code: [src/commands/edge/drivers/package.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/drivers/package.ts)_
+_See code: [src/commands/edge/drivers/package.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/drivers/package.ts)_
 
 ## `smartthings edge:drivers:publish [DRIVERID] [VERSION]`
 
@@ -997,7 +997,7 @@ DESCRIPTION
   uninstall an edge driver from a hub
 ```
 
-_See code: [src/commands/edge/drivers/uninstall.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.10.1/src/commands/edge/drivers/uninstall.ts)_
+_See code: [src/commands/edge/drivers/uninstall.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.11.0/src/commands/edge/drivers/uninstall.ts)_
 
 ## `smartthings edge:drivers:unpublish [DRIVERID]`
 

--- a/src/commands/edge/channels.ts
+++ b/src/commands/edge/channels.ts
@@ -18,6 +18,7 @@ export default class ChannelsCommand extends EdgeCommand {
 		'include-read-only': Flags.boolean({
 			char: 'I',
 			description: 'include subscribed-to channels as well as owned channels',
+			exclusive: ['all-organizations'],
 		}),
 		'subscriber-type': Flags.string({
 			description: 'filter results based on subscriber type',
@@ -62,7 +63,11 @@ $ smartthings edge:channels --subscriber-type HUB --subscriber-id <hub-id>`]
 		}
 
 		await outputListing(this, config, args.idOrIndex,
-			async () => listChannels(this, flags['subscriber-type'] as SubscriberType | undefined, flags['subscriber-id']),
+			async () => listChannels(this.client, {
+				subscriberType: flags['subscriber-type'] as SubscriberType | undefined,
+				subscriberId: flags['subscriber-id'],
+				includeReadOnly: flags['include-read-only'],
+			}),
 			id => this.client.channels.get(id))
 	}
 }

--- a/test/unit/commands/edge/channels.test.ts
+++ b/test/unit/commands/edge/channels.test.ts
@@ -1,6 +1,6 @@
-import { Channel, ChannelsEndpoint } from '@smartthings/core-sdk'
+import { Channel, ChannelsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
 
-import { APICommand, outputListing } from '@smartthings/cli-lib'
+import { outputListing } from '@smartthings/cli-lib'
 
 import ChannelsCommand from '../../../../src/commands/edge/channels'
 import { listChannels } from '../../../../src/lib/commands/channels-util'
@@ -78,7 +78,8 @@ describe('ChannelsCommand', () => {
 		expect(await listFunction()).toBe(channelList)
 
 		expect(listChannelsMock).toHaveBeenCalledTimes(1)
-		expect(listChannelsMock).toHaveBeenCalledWith(expect.any(APICommand), 'HUB', 'subscriber-id')
+		expect(listChannelsMock).toHaveBeenCalledWith(expect.any(SmartThingsClient),
+			{ subscriberType: 'HUB', subscriberId: 'subscriber-id' })
 	})
 
 	test('get item function uses channels.get with id', async () => {


### PR DESCRIPTION
<!-- Describe your pull request. -->

* clean up `listChannels` function to not allow `includeReadOnly` and `allOrganizations` at the same time
* updated `edge:channels` command to mark the corresponding flags exclusive of each other

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [x] I have added tests to cover my changes
