### PR TITLE
feat: add support for switching drivers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,8 @@ module.exports = {
 	},
 	parserOptions: {
 		ecmaVersion: 2018,
+		tsconfigRootDir: __dirname,
+		project: ['./tsconfig.json', './test/tsconfig-eslint.json'],
 	},
 	rules: {
 		indent: 'off',
@@ -80,6 +82,8 @@ module.exports = {
 			{ functions: false, classes: false, enums: false, variables: true },
 		],
 		'@typescript-eslint/no-var-requires': 'error',
+		'@typescript-eslint/no-floating-promises': 'error',
+		'@typescript-eslint/space-infix-ops': 'error',
 
 		// disallow non-import statements appearing before import statements
 		'import/first': 'error',

--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ for information on running the CLI.
 * [`smartthings edge:channels:unenroll [HUBID]`](#smartthings-edgechannelsunenroll-hubid)
 * [`smartthings edge:channels:update [ID]`](#smartthings-edgechannelsupdate-id)
 * [`smartthings edge:drivers [IDORINDEX]`](#smartthings-edgedrivers-idorindex)
+* [`smartthings edge:drivers:default`](#smartthings-edgedriversdefault)
 * [`smartthings edge:drivers:delete [ID]`](#smartthings-edgedriversdelete-id)
 * [`smartthings edge:drivers:install [DRIVERID]`](#smartthings-edgedriversinstall-driverid)
 * [`smartthings edge:drivers:installed [IDORINDEX]`](#smartthings-edgedriversinstalled-idorindex)
 * [`smartthings edge:drivers:logcat [DRIVERID]`](#smartthings-edgedriverslogcat-driverid)
 * [`smartthings edge:drivers:package [PROJECTDIRECTORY]`](#smartthings-edgedriverspackage-projectdirectory)
 * [`smartthings edge:drivers:publish [DRIVERID] [VERSION]`](#smartthings-edgedriverspublish-driverid-version)
+* [`smartthings edge:drivers:switch [DEVICEID]`](#smartthings-edgedriversswitch-deviceid)
 * [`smartthings edge:drivers:uninstall [DRIVERID]`](#smartthings-edgedriversuninstall-driverid)
 * [`smartthings edge:drivers:unpublish [DRIVERID]`](#smartthings-edgedriversunpublish-driverid)
 
@@ -94,7 +96,7 @@ EXAMPLES
   $ smartthings edge:channels --subscriber-type HUB --subscriber-id <hub-id>
 ```
 
-_See code: [src/commands/edge/channels.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels.ts)_
+_See code: [src/commands/edge/channels.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels.ts)_
 
 ## `smartthings edge:channels:assign [DRIVERID] [VERSION]`
 
@@ -124,7 +126,7 @@ ALIASES
   $ smartthings edge:drivers:publish
 ```
 
-_See code: [src/commands/edge/channels/assign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/assign.ts)_
+_See code: [src/commands/edge/channels/assign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/assign.ts)_
 
 ## `smartthings edge:channels:assignments [IDORINDEX]`
 
@@ -180,7 +182,7 @@ DESCRIPTION
   create a channel
 ```
 
-_See code: [src/commands/edge/channels/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/create.ts)_
+_See code: [src/commands/edge/channels/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/create.ts)_
 
 ## `smartthings edge:channels:delete [ID]`
 
@@ -204,7 +206,7 @@ DESCRIPTION
   delete a channel
 ```
 
-_See code: [src/commands/edge/channels/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/delete.ts)_
+_See code: [src/commands/edge/channels/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/delete.ts)_
 
 ## `smartthings edge:channels:drivers [IDORINDEX]`
 
@@ -235,7 +237,7 @@ ALIASES
   $ smartthings edge:channels:assignments
 ```
 
-_See code: [src/commands/edge/channels/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/drivers.ts)_
+_See code: [src/commands/edge/channels/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/drivers.ts)_
 
 ## `smartthings edge:channels:enroll [HUBID]`
 
@@ -261,7 +263,7 @@ DESCRIPTION
   enroll a hub in a channel
 ```
 
-_See code: [src/commands/edge/channels/enroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/enroll.ts)_
+_See code: [src/commands/edge/channels/enroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/enroll.ts)_
 
 ## `smartthings edge:channels:enrollments [IDORINDEX]`
 
@@ -289,7 +291,7 @@ DESCRIPTION
   list all channels a given hub is enrolled in
 ```
 
-_See code: [src/commands/edge/channels/enrollments.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/enrollments.ts)_
+_See code: [src/commands/edge/channels/enrollments.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/enrollments.ts)_
 
 ## `smartthings edge:channels:invitations [IDORINDEX]`
 
@@ -481,7 +483,7 @@ EXAMPLES
   $ smartthings edge:channels:invites <invite id>      # list details about the invite with id <invite id>
 ```
 
-_See code: [src/commands/edge/channels/invites.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/invites.ts)_
+_See code: [src/commands/edge/channels/invites.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/invites.ts)_
 
 ## `smartthings edge:channels:invites:accept ID`
 
@@ -508,7 +510,7 @@ ALIASES
   $ smartthings edge:channels:invitations:accept
 ```
 
-_See code: [src/commands/edge/channels/invites/accept.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/invites/accept.ts)_
+_See code: [src/commands/edge/channels/invites/accept.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/invites/accept.ts)_
 
 ## `smartthings edge:channels:invites:create`
 
@@ -539,7 +541,7 @@ ALIASES
   $ smartthings edge:channels:invitations:create
 ```
 
-_See code: [src/commands/edge/channels/invites/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/invites/create.ts)_
+_See code: [src/commands/edge/channels/invites/create.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/invites/create.ts)_
 
 ## `smartthings edge:channels:invites:delete [ID]`
 
@@ -570,7 +572,7 @@ ALIASES
   $ smartthings edge:channels:invites:revoke
 ```
 
-_See code: [src/commands/edge/channels/invites/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/invites/delete.ts)_
+_See code: [src/commands/edge/channels/invites/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/invites/delete.ts)_
 
 ## `smartthings edge:channels:invites:revoke [ID]`
 
@@ -641,7 +643,7 @@ EXAMPLES
       699c7308-8c72-4363-9571-880d0f5cc725
 ```
 
-_See code: [src/commands/edge/channels/metainfo.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/metainfo.ts)_
+_See code: [src/commands/edge/channels/metainfo.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/metainfo.ts)_
 
 ## `smartthings edge:channels:unassign [DRIVERID]`
 
@@ -670,7 +672,7 @@ ALIASES
   $ smartthings edge:drivers:unpublish
 ```
 
-_See code: [src/commands/edge/channels/unassign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/unassign.ts)_
+_See code: [src/commands/edge/channels/unassign.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/unassign.ts)_
 
 ## `smartthings edge:channels:unenroll [HUBID]`
 
@@ -696,7 +698,7 @@ DESCRIPTION
   unenroll a hub from a channel
 ```
 
-_See code: [src/commands/edge/channels/unenroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/unenroll.ts)_
+_See code: [src/commands/edge/channels/unenroll.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/unenroll.ts)_
 
 ## `smartthings edge:channels:update [ID]`
 
@@ -726,7 +728,7 @@ DESCRIPTION
   update a channel
 ```
 
-_See code: [src/commands/edge/channels/update.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/channels/update.ts)_
+_See code: [src/commands/edge/channels/update.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/channels/update.ts)_
 
 ## `smartthings edge:drivers [IDORINDEX]`
 
@@ -775,7 +777,37 @@ EXAMPLES
   $ smartthings edge:drivers 699c7308-8c72-4363-9571-880d0f5cc725 --version 2021-10-25T00:48:23.295969
 ```
 
-_See code: [src/commands/edge/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/drivers.ts)_
+_See code: [src/commands/edge/drivers.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/drivers.ts)_
+
+## `smartthings edge:drivers:default`
+
+list default drivers available to all users
+
+```
+USAGE
+  $ smartthings edge:drivers:default [-h] [-p <value>] [-t <value>] [--language <value>] [-O <value>] [-j] [-y] [-o
+    <value>]
+
+FLAGS
+  -O, --organization=<value>  The organization ID to use for this command
+  -h, --help                  Show CLI help.
+  -j, --json                  use JSON format of input and/or output
+  -o, --output=<value>        specify output file
+  -p, --profile=<value>       [default: default] configuration profile
+  -t, --token=<value>         the auth token to use
+  -y, --yaml                  use YAML format of input and/or output
+  --language=<value>          ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+
+DESCRIPTION
+  list default drivers available to all users
+
+EXAMPLES
+  # list default drivers
+
+    $ smartthings edge:drivers:default
+```
+
+_See code: [src/commands/edge/drivers/default.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/drivers/default.ts)_
 
 ## `smartthings edge:drivers:delete [ID]`
 
@@ -799,7 +831,7 @@ DESCRIPTION
   delete an edge driver
 ```
 
-_See code: [src/commands/edge/drivers/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/drivers/delete.ts)_
+_See code: [src/commands/edge/drivers/delete.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/drivers/delete.ts)_
 
 ## `smartthings edge:drivers:install [DRIVERID]`
 
@@ -833,7 +865,7 @@ EXAMPLES
   $ smartthings edge:drivers:install -H <hub-id> -C <channel-id> <driver-id> # install a driver from a channel on an enrolled hub
 ```
 
-_See code: [src/commands/edge/drivers/install.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/drivers/install.ts)_
+_See code: [src/commands/edge/drivers/install.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/drivers/install.ts)_
 
 ## `smartthings edge:drivers:installed [IDORINDEX]`
 
@@ -842,7 +874,7 @@ list all drivers installed on a given hub
 ```
 USAGE
   $ smartthings edge:drivers:installed [IDORINDEX] [-h] [-p <value>] [-t <value>] [--language <value>] [-O <value>] [-j]
-    [-y] [-o <value>] [-H <value>]
+    [-y] [-o <value>] [-H <value>] [--device <value>]
 
 ARGUMENTS
   IDORINDEX  the driver id or number in list
@@ -856,13 +888,14 @@ FLAGS
   -p, --profile=<value>       [default: default] configuration profile
   -t, --token=<value>         the auth token to use
   -y, --yaml                  use YAML format of input and/or output
+  --device=<value>            return drivers matching the specified device
   --language=<value>          ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 
 DESCRIPTION
   list all drivers installed on a given hub
 ```
 
-_See code: [src/commands/edge/drivers/installed.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/drivers/installed.ts)_
+_See code: [src/commands/edge/drivers/installed.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/drivers/installed.ts)_
 
 ## `smartthings edge:drivers:logcat [DRIVERID]`
 
@@ -889,7 +922,7 @@ DESCRIPTION
   stream logs from installed drivers
 ```
 
-_See code: [src/commands/edge/drivers/logcat.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/drivers/logcat.ts)_
+_See code: [src/commands/edge/drivers/logcat.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/drivers/logcat.ts)_
 
 ## `smartthings edge:drivers:package [PROJECTDIRECTORY]`
 
@@ -943,7 +976,7 @@ EXAMPLES
     $ smartthings edge:drivers:package -u driver.zip
 ```
 
-_See code: [src/commands/edge/drivers/package.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/drivers/package.ts)_
+_See code: [src/commands/edge/drivers/package.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/drivers/package.ts)_
 
 ## `smartthings edge:drivers:publish [DRIVERID] [VERSION]`
 
@@ -973,6 +1006,45 @@ ALIASES
   $ smartthings edge:drivers:publish
 ```
 
+## `smartthings edge:drivers:switch [DEVICEID]`
+
+change the driver used by an installed device
+
+```
+USAGE
+  $ smartthings edge:drivers:switch [DEVICEID] [-h] [-p <value>] [-t <value>] [--language <value>] [-O <value>] [-H
+    <value>] [-d <value>] [-I]
+
+ARGUMENTS
+  DEVICEID  id of device to update
+
+FLAGS
+  -H, --hub=<value>           hub id
+  -I, --include-non-matching  when presenting a list of drivers to switch to, include drivers that do not match the
+                              device
+  -O, --organization=<value>  The organization ID to use for this command
+  -d, --driver=<value>        id of new driver to use
+  -h, --help                  Show CLI help.
+  -p, --profile=<value>       [default: default] configuration profile
+  -t, --token=<value>         the auth token to use
+  --language=<value>          ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+
+DESCRIPTION
+  change the driver used by an installed device
+
+EXAMPLES
+  # switch driver, prompting user for all necessary input
+  $ smartthings edge:drivers:switch
+  # switch driver, including all necessary input on the command line
+  $ smartthings edge:drivers:switch --hub <hub-id> --driver <driver-id> <device-id>
+
+  # include all available drivers in prompt, even if they don't match the chosen device
+
+    $ smartthings edge:drivers:switch --include-non-matching
+```
+
+_See code: [src/commands/edge/drivers/switch.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/drivers/switch.ts)_
+
 ## `smartthings edge:drivers:uninstall [DRIVERID]`
 
 uninstall an edge driver from a hub
@@ -997,7 +1069,7 @@ DESCRIPTION
   uninstall an edge driver from a hub
 ```
 
-_See code: [src/commands/edge/drivers/uninstall.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.12.0/src/commands/edge/drivers/uninstall.ts)_
+_See code: [src/commands/edge/drivers/uninstall.ts](https://github.com/SmartThingsCommunity/edge-cli-plugin/blob/v1.13.0/src/commands/edge/drivers/uninstall.ts)_
 
 ## `smartthings edge:drivers:unpublish [DRIVERID]`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@log4js-node/log4js-api": "^1.0.2",
 				"@oclif/core": "^1.7.0",
 				"@smartthings/cli-lib": "^1.0.0-beta.6",
-				"@smartthings/core-sdk": "^3.4.1",
+				"@smartthings/core-sdk": "^3.6.0",
 				"axios": "^0.21.4",
 				"inquirer": "^8.2.2",
 				"js-yaml": "^4.1.0",
@@ -22,7 +22,7 @@
 			},
 			"devDependencies": {
 				"@semantic-release/git": "^10.0.1",
-				"@smartthings/cli-testlib": "^1.0.0-beta.3",
+				"@smartthings/cli-testlib": "^1.0.0-beta.4",
 				"@types/cli-table": "^0.3.0",
 				"@types/eventsource": "^1.1.8",
 				"@types/inquirer": "^8.2.1",
@@ -2416,12 +2416,12 @@
 			}
 		},
 		"node_modules/@smartthings/cli-testlib": {
-			"version": "1.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/@smartthings/cli-testlib/-/cli-testlib-1.0.0-beta.3.tgz",
-			"integrity": "sha512-KePnEAPMgtALZRW5Mvlhrq4W37/kf8T6Ln0YiomxWhOWHIZ7nw3N2Ct8/CIvpcE4DMO4rjRlYqJv3azA76gAyA==",
+			"version": "1.0.0-beta.4",
+			"resolved": "https://registry.npmjs.org/@smartthings/cli-testlib/-/cli-testlib-1.0.0-beta.4.tgz",
+			"integrity": "sha512-xOWRU2d9nv+dx5yytw4ksdaOSitgS6/q40Z6f1mK2n69iXzR/C+xxwedVrcaEVq/xH+enj+y8Wdt52onVz6/MA==",
 			"dev": true,
 			"dependencies": {
-				"@smartthings/cli-lib": "^1.0.0-beta.5",
+				"@smartthings/cli-lib": "^1.0.0-beta.6",
 				"@smartthings/core-sdk": "^3.4.1"
 			},
 			"engines": {
@@ -2430,9 +2430,9 @@
 			}
 		},
 		"node_modules/@smartthings/core-sdk": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-3.4.1.tgz",
-			"integrity": "sha512-5pincw51e/nSpn+YanJlBYn/sTx8Nx5xnGWLntJsdUKv6WZM3gu29+6WyrCKpsFywu0FBHwYND0KS/ieZ8J0pA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-3.6.0.tgz",
+			"integrity": "sha512-4med6fWOXyUJdkw2l+pXSxqOQBy4aqBRP27ZJkmYftyHvTvaNpJJRaa8ZSrPJlfsuPLJC4N7M/ZQjOzZd8i2sQ==",
 			"dependencies": {
 				"async-mutex": "^0.3.2",
 				"axios": "^0.21.4",
@@ -19520,19 +19520,19 @@
 			}
 		},
 		"@smartthings/cli-testlib": {
-			"version": "1.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/@smartthings/cli-testlib/-/cli-testlib-1.0.0-beta.3.tgz",
-			"integrity": "sha512-KePnEAPMgtALZRW5Mvlhrq4W37/kf8T6Ln0YiomxWhOWHIZ7nw3N2Ct8/CIvpcE4DMO4rjRlYqJv3azA76gAyA==",
+			"version": "1.0.0-beta.4",
+			"resolved": "https://registry.npmjs.org/@smartthings/cli-testlib/-/cli-testlib-1.0.0-beta.4.tgz",
+			"integrity": "sha512-xOWRU2d9nv+dx5yytw4ksdaOSitgS6/q40Z6f1mK2n69iXzR/C+xxwedVrcaEVq/xH+enj+y8Wdt52onVz6/MA==",
 			"dev": true,
 			"requires": {
-				"@smartthings/cli-lib": "^1.0.0-beta.5",
+				"@smartthings/cli-lib": "^1.0.0-beta.6",
 				"@smartthings/core-sdk": "^3.4.1"
 			}
 		},
 		"@smartthings/core-sdk": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-3.4.1.tgz",
-			"integrity": "sha512-5pincw51e/nSpn+YanJlBYn/sTx8Nx5xnGWLntJsdUKv6WZM3gu29+6WyrCKpsFywu0FBHwYND0KS/ieZ8J0pA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-3.6.0.tgz",
+			"integrity": "sha512-4med6fWOXyUJdkw2l+pXSxqOQBy4aqBRP27ZJkmYftyHvTvaNpJJRaa8ZSrPJlfsuPLJC4N7M/ZQjOzZd8i2sQ==",
 			"requires": {
 				"async-mutex": "^0.3.2",
 				"axios": "^0.21.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"@log4js-node/log4js-api": "^1.0.2",
 		"@oclif/core": "^1.7.0",
 		"@smartthings/cli-lib": "^1.0.0-beta.6",
-		"@smartthings/core-sdk": "^3.4.1",
+		"@smartthings/core-sdk": "^3.6.0",
 		"axios": "^0.21.4",
 		"inquirer": "^8.2.2",
 		"js-yaml": "^4.1.0",
@@ -47,7 +47,7 @@
 	},
 	"devDependencies": {
 		"@semantic-release/git": "^10.0.1",
-		"@smartthings/cli-testlib": "^1.0.0-beta.3",
+		"@smartthings/cli-testlib": "^1.0.0-beta.4",
 		"@types/cli-table": "^0.3.0",
 		"@types/eventsource": "^1.1.8",
 		"@types/inquirer": "^8.2.1",

--- a/src/commands/edge/drivers/default.ts
+++ b/src/commands/edge/drivers/default.ts
@@ -1,0 +1,27 @@
+import { outputList } from '@smartthings/cli-lib'
+
+import { EdgeCommand } from '../../../lib/edge-command'
+import { listTableFieldDefinitions } from '../../../lib/commands/drivers-util'
+
+
+export default class DriversDefaultCommand extends EdgeCommand<typeof DriversDefaultCommand.flags> {
+	static description = 'list default drivers available to all users'
+
+	static flags = {
+		...EdgeCommand.flags,
+		...outputList.flags,
+	}
+
+	static examples = [`# list default drivers
+$ smartthings edge:drivers:default`]
+
+	async run(): Promise<void> {
+		const config = {
+			primaryKeyName: 'driverId',
+			sortKeyName: 'name',
+			listTableFieldDefinitions,
+		}
+
+		await outputList(this, config, () => this.client.drivers.listDefault())
+	}
+}

--- a/src/commands/edge/drivers/installed.ts
+++ b/src/commands/edge/drivers/installed.ts
@@ -16,6 +16,9 @@ export default class DriversInstalledCommand extends EdgeCommand<typeof DriversI
 			char: 'H',
 			description: 'hub id',
 		}),
+		device: Flags.string({
+			description: 'return drivers matching the specified device',
+		}),
 	}
 
 	static args = [{
@@ -37,7 +40,7 @@ export default class DriversInstalledCommand extends EdgeCommand<typeof DriversI
 			{ allowIndex: true, useConfigDefault: true })
 
 		await outputListing(this, config, this.args.idOrIndex,
-			() => this.edgeClient.hubs.listInstalled(hubId),
+			() => this.edgeClient.hubs.listInstalled(hubId, this.flags.device),
 			id => this.edgeClient.hubs.getInstalled(hubId, id))
 	}
 }

--- a/src/commands/edge/drivers/package.ts
+++ b/src/commands/edge/drivers/package.ts
@@ -89,11 +89,13 @@ $ smartthings edge:drivers:package -u driver.zip`]
 				const channelId = await chooseChannel(this, 'Select a channel for the driver.',
 					this.flags.channel, { useConfigDefault: true })
 				await this.client.channels.assignDriver(channelId, driverId, version)
+				this.log(`assigned driver ${driverId} ${version} to channel ${channelId}`)
 
 				if (doInstall) {
 					const hubId = await chooseHub(this, 'Select a hub to install to.', this.flags.hub,
 						{ useConfigDefault: true })
 					await this.edgeClient.hubs.installDriver(driverId, hubId, channelId)
+					this.log(`installed driver ${driverId} ${version} to hub ${hubId}`)
 				}
 			}
 		}

--- a/src/commands/edge/drivers/switch.ts
+++ b/src/commands/edge/drivers/switch.ts
@@ -1,0 +1,75 @@
+import { Flags } from '@oclif/core'
+
+import { Device, DeviceIntegrationType } from '@smartthings/core-sdk'
+
+import { chooseDevice } from '@smartthings/cli-lib'
+
+import { EdgeCommand } from '../../../lib/edge-command'
+import { chooseDriver, chooseHub, listAllAvailableDrivers, listMatchingDrivers }
+	from '../../../lib/commands/drivers-util'
+
+
+export default class DriversSwitchCommand extends EdgeCommand<typeof DriversSwitchCommand.flags> {
+	static description = 'change the driver used by an installed device'
+
+	static examples = [`# switch driver, prompting user for all necessary input
+$ smartthings edge:drivers:switch
+
+# switch driver, including all necessary input on the command line
+$ smartthings edge:drivers:switch --hub <hub-id> --driver <driver-id> <device-id>`,
+	`
+# include all available drivers in prompt, even if they don't match the chosen device
+$ smartthings edge:drivers:switch --include-non-matching`,
+	]
+
+	static flags = {
+		...EdgeCommand.flags,
+		hub: Flags.string({
+			char: 'H',
+			description: 'hub id',
+		}),
+		driver: Flags.string({
+			char: 'd',
+			description: 'id of new driver to use',
+		}),
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		'include-non-matching': Flags.boolean({
+			char: 'I',
+			description: 'when presenting a list of drivers to switch to, include drivers that do not match the device',
+		}),
+	}
+
+	static args = [{
+		name: 'deviceId',
+		description: 'id of device to update',
+	}]
+
+	async run(): Promise<void> {
+		const hubId = await chooseHub(this, 'Which hub is the device connected to?',
+			this.flags.hub, { useConfigDefault: true })
+		const deviceListFilter = (device: Device): boolean =>
+			device.type === DeviceIntegrationType.LAN && device.lan?.hubId === hubId ||
+			device.type === DeviceIntegrationType.MATTER && device.matter?.hubId === hubId ||
+			device.type === DeviceIntegrationType.ZIGBEE && device.zigbee?.hubId === hubId ||
+			device.type === DeviceIntegrationType.ZWAVE && device.zwave?.hubId === hubId
+
+		const deviceListOptions = {
+			type: [
+				DeviceIntegrationType.LAN,
+				DeviceIntegrationType.MATTER,
+				DeviceIntegrationType.ZIGBEE,
+				DeviceIntegrationType.ZWAVE,
+			],
+		}
+		const deviceId = await chooseDevice(this, this.args.deviceId, { deviceListOptions, deviceListFilter })
+
+		const listItems = this.flags['include-non-matching']
+			? () => listAllAvailableDrivers(this.client, this.edgeClient, deviceId, hubId)
+			: () => listMatchingDrivers(this.client, this.edgeClient, deviceId, hubId)
+		const driverId = await chooseDriver(this, 'Choose a driver to use.', this.flags.driver,
+			{ listItems })
+
+		await this.edgeClient.hubs.switchDriver(driverId, hubId, deviceId)
+		this.log(`updated driver for device ${deviceId} to ${driverId}`)
+	}
+}

--- a/src/lib/endpoints/hubs.ts
+++ b/src/lib/endpoints/hubs.ts
@@ -35,12 +35,25 @@ export class HubsEndpoint extends Endpoint {
 		return this.client.put(`${hubId}/drivers/${driverId}`, { channelId })
 	}
 
+	/**
+	 * Change the driver for a device to the one specified by driverId.
+	 */
+	public async switchDriver(driverId: string, hubId: string, deviceId: string): Promise<void> {
+		return this.client.patch(`${hubId}/childdevice/${deviceId}`, { driverId })
+	}
+
 	public async uninstallDriver(driverId: string, hubId: string): Promise<void> {
 		return this.client.delete(`${hubId}/drivers/${driverId}`)
 	}
 
-	public async listInstalled(hubId: string): Promise<InstalledDriver[]> {
-		return this.client.get(`${hubId}/drivers`)
+	/**
+	 * List drivers installed on the hub.
+	 *
+	 * @param deviceId When included, limit the drivers to those marked as matching the specified device.
+	 */
+	public async listInstalled(hubId: string, deviceId?: string): Promise<InstalledDriver[]> {
+		const params = deviceId? { deviceId } : undefined
+		return this.client.get(`${hubId}/drivers`, params)
 	}
 
 	public async getInstalled(hubId: string, driverId: string): Promise<InstalledDriver> {

--- a/src/lib/endpoints/hubs.ts
+++ b/src/lib/endpoints/hubs.ts
@@ -52,7 +52,7 @@ export class HubsEndpoint extends Endpoint {
 	 * @param deviceId When included, limit the drivers to those marked as matching the specified device.
 	 */
 	public async listInstalled(hubId: string, deviceId?: string): Promise<InstalledDriver[]> {
-		const params = deviceId? { deviceId } : undefined
+		const params = deviceId ? { deviceId } : undefined
 		return this.client.get(`${hubId}/drivers`, params)
 	}
 

--- a/test/tsconfig-eslint.json
+++ b/test/tsconfig-eslint.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"types": ["jest"],
+		"rootDir": "..",
+		"noEmit": true,
+	},
+	"include": ["."],
+}

--- a/test/unit/commands/edge/drivers/default.test.ts
+++ b/test/unit/commands/edge/drivers/default.test.ts
@@ -1,0 +1,52 @@
+import { DriversEndpoint, EdgeDriverSummary } from '@smartthings/core-sdk'
+
+import { outputList } from '@smartthings/cli-lib'
+
+import DriversDefaultCommand from '../../../../../src/commands/edge/drivers/default'
+
+
+jest.mock('@smartthings/cli-lib', () => {
+	const originalLib = jest.requireActual('@smartthings/cli-lib')
+
+	return {
+		...originalLib,
+		outputList: jest.fn(),
+	}
+})
+jest.mock('../../../../../src/lib/commands/drivers-util')
+
+describe('DriversDefaultCommand', () => {
+	afterEach(() => {
+		jest.clearAllMocks()
+	})
+
+	const outputListMock = jest.mocked(outputList)
+
+	it('uses outputList', async () => {
+		await expect(DriversDefaultCommand.run([])).resolves.not.toThrow()
+
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledWith(
+			expect.any(DriversDefaultCommand),
+			expect.objectContaining({ primaryKeyName: 'driverId' }),
+			expect.any(Function),
+		)
+	})
+
+	it('uses listDefaultDrivers to list drivers', async () => {
+		await expect(DriversDefaultCommand.run([])).resolves.not.toThrow()
+
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+
+		const listFunction = outputListMock.mock.calls[0][2]
+
+		const driverList = [{ driverId: 'driver-in-list-id' }] as EdgeDriverSummary[]
+		const listDefaultSpy = jest.spyOn(DriversEndpoint.prototype, 'listDefault')
+			.mockResolvedValueOnce(driverList)
+
+		expect(await listFunction()).toBe(driverList)
+
+		expect(listDefaultSpy).toHaveBeenCalledTimes(1)
+		expect(listDefaultSpy).toHaveBeenCalledWith()
+	})
+})

--- a/test/unit/commands/edge/drivers/delete.test.ts
+++ b/test/unit/commands/edge/drivers/delete.test.ts
@@ -1,0 +1,27 @@
+import { DriversEndpoint } from '@smartthings/core-sdk'
+
+import DriversDeleteCommand from '../../../../../src/commands/edge/drivers/delete'
+import { chooseDriver } from '../../../../../src/lib/commands/drivers-util'
+
+
+jest.mock('../../../../../src/lib/commands/drivers-util')
+
+describe('DriversDeleteCommand', () => {
+	const chooseDriverMock = jest.mocked(chooseDriver).mockResolvedValue('chosen-driver-id')
+	const apiDriversDeleteSpy = jest.spyOn(DriversEndpoint.prototype, 'delete').mockImplementation()
+
+	afterEach(() => {
+		jest.clearAllMocks()
+	})
+
+	it('deletes driver', async () => {
+		await expect(DriversDeleteCommand.run(['cmd-line-driver-id'])).resolves.not.toThrow()
+
+		expect(chooseDriverMock).toHaveBeenCalledTimes(1)
+		expect(chooseDriverMock).toHaveBeenCalledWith(expect.any(DriversDeleteCommand),
+			'Select a driver to delete.', 'cmd-line-driver-id')
+
+		expect(apiDriversDeleteSpy).toHaveBeenCalledTimes(1)
+		expect(apiDriversDeleteSpy).toHaveBeenCalledWith('chosen-driver-id')
+	})
+})

--- a/test/unit/commands/edge/drivers/installed.test.ts
+++ b/test/unit/commands/edge/drivers/installed.test.ts
@@ -1,0 +1,89 @@
+import { outputListing } from '@smartthings/cli-lib'
+
+import DriversInstalledCommand from '../../../../../src/commands/edge/drivers/installed'
+import { chooseHub } from '../../../../../src/lib/commands/drivers-util'
+import { HubsEndpoint, InstalledDriver } from '../../../../../src/lib/endpoints/hubs'
+
+
+jest.mock('@smartthings/cli-lib', () => {
+	const originalLib = jest.requireActual('@smartthings/cli-lib')
+
+	return {
+		...originalLib,
+		outputListing: jest.fn(),
+	}
+})
+jest.mock('../../../../../src/lib/commands/drivers-util')
+
+describe('DriversInstalledCommand', () => {
+	const hub = { name: 'Hub' } as InstalledDriver
+	const chooseHubMock = jest.mocked(chooseHub).mockResolvedValue('chosen-hub-id')
+	const apiHubsListInstalledSpy = jest.spyOn(HubsEndpoint.prototype, 'listInstalled').mockResolvedValue([hub])
+	const apiHubsGetInstalledSpy = jest.spyOn(HubsEndpoint.prototype, 'getInstalled').mockResolvedValue(hub)
+	const outputListingMock = jest.mocked(outputListing)
+
+	afterEach(() => {
+		jest.clearAllMocks()
+	})
+
+	it('uses outputListing', async () => {
+		await expect(DriversInstalledCommand.run([])).resolves.not.toThrow()
+
+		expect(chooseHubMock).toHaveBeenCalledTimes(1)
+		expect(chooseHubMock).toHaveBeenCalledWith(expect.any(DriversInstalledCommand),
+			'Select a hub.', undefined, { allowIndex: true, useConfigDefault: true })
+
+		expect(outputListingMock).toHaveBeenCalledTimes(1)
+		expect(outputListingMock).toHaveBeenCalledWith(
+			expect.any(DriversInstalledCommand),
+			expect.objectContaining({ primaryKeyName: 'channelId' }),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+		)
+	})
+
+	it('uses hub id from command line', async () => {
+		await expect(DriversInstalledCommand.run(['--hub', 'cmd-line-hub-id'])).resolves.not.toThrow()
+
+		expect(chooseHubMock).toHaveBeenCalledTimes(1)
+		expect(chooseHubMock).toHaveBeenCalledWith(expect.any(DriversInstalledCommand),
+			'Select a hub.', 'cmd-line-hub-id', { allowIndex: true, useConfigDefault: true })
+
+		expect(outputListingMock).toHaveBeenCalledTimes(1)
+	})
+
+	test('list function', async () => {
+		await expect(DriversInstalledCommand.run(['--device', 'cmd-line-device-id'])).resolves.not.toThrow()
+
+		expect(chooseHubMock).toHaveBeenCalledTimes(1)
+		expect(chooseHubMock).toHaveBeenCalledWith(expect.any(DriversInstalledCommand),
+			'Select a hub.', undefined, { allowIndex: true, useConfigDefault: true })
+
+		expect(outputListingMock).toHaveBeenCalledTimes(1)
+
+		const listFunction = outputListingMock.mock.calls[0][3]
+
+		expect(await listFunction()).toStrictEqual([hub])
+
+		expect(apiHubsListInstalledSpy).toHaveBeenCalledTimes(1)
+		expect(apiHubsListInstalledSpy).toHaveBeenCalledWith('chosen-hub-id', 'cmd-line-device-id')
+	})
+
+	test('get function', async () => {
+		await expect(DriversInstalledCommand.run(['cmd-line-driver-id'])).resolves.not.toThrow()
+
+		expect(chooseHubMock).toHaveBeenCalledTimes(1)
+		expect(chooseHubMock).toHaveBeenCalledWith(expect.any(DriversInstalledCommand),
+			'Select a hub.', undefined, { allowIndex: true, useConfigDefault: true })
+
+		expect(outputListingMock).toHaveBeenCalledTimes(1)
+
+		const getFunction = outputListingMock.mock.calls[0][4]
+
+		expect(await getFunction('chosen-device-id')).toBe(hub)
+
+		expect(apiHubsGetInstalledSpy).toHaveBeenCalledTimes(1)
+		expect(apiHubsGetInstalledSpy).toHaveBeenCalledWith('chosen-hub-id', 'chosen-device-id')
+	})
+})

--- a/test/unit/commands/edge/drivers/package.test.ts
+++ b/test/unit/commands/edge/drivers/package.test.ts
@@ -69,8 +69,8 @@ describe('PackageCommand', () => {
 
 	const driver = { driverId: 'driver id', version: 'driver version' } as EdgeDriver
 	const outputItemMock = jest.mocked(outputItem)
-		.mockImplementation((_command, _config, actionFunction): Promise<EdgeDriver> => {
-			actionFunction()
+		.mockImplementation(async (_command, _config, actionFunction): Promise<EdgeDriver> => {
+			await actionFunction()
 			return Promise.resolve(driver)
 		})
 	const uploadSpy = jest.spyOn(DriversEndpoint.prototype, 'upload').mockResolvedValue(driver)

--- a/test/unit/commands/edge/drivers/switch.test.ts
+++ b/test/unit/commands/edge/drivers/switch.test.ts
@@ -1,0 +1,154 @@
+import { Device, DeviceIntegrationType, SmartThingsClient } from '@smartthings/core-sdk'
+
+import { chooseDevice } from '@smartthings/cli-lib'
+
+import DriversSwitchCommand from '../../../../../src/commands/edge/drivers/switch'
+import { chooseDriver, chooseHub, listAllAvailableDrivers, listMatchingDrivers }
+	from '../../../../../src/lib/commands/drivers-util'
+import { HubsEndpoint } from '../../../../../src/lib/endpoints/hubs'
+import { EdgeClient } from '../../../../../src/lib/edge-client'
+
+
+const edgeDeviceIntegrationTypes = [
+	DeviceIntegrationType.LAN,
+	DeviceIntegrationType.MATTER,
+	DeviceIntegrationType.ZIGBEE,
+	DeviceIntegrationType.ZWAVE,
+]
+
+jest.mock('@smartthings/cli-lib', () => {
+	const originalLib = jest.requireActual('@smartthings/cli-lib')
+
+	return {
+		...originalLib,
+		chooseDevice: jest.fn(),
+	}
+})
+jest.mock('../../../../../src/lib/commands/drivers-util')
+
+describe('DriversSwitchCommand', () => {
+	afterEach(() => {
+		jest.clearAllMocks()
+	})
+
+	const changeDriverSpy = jest.spyOn(HubsEndpoint.prototype, 'switchDriver').mockImplementation()
+	const chooseHubMock = jest.mocked(chooseHub).mockResolvedValue('chosen-hub-id')
+	const chooseDeviceMock = jest.mocked(chooseDevice).mockResolvedValue('chosen-device-id')
+	const chooseDriverMock = jest.mocked(chooseDriver).mockResolvedValue('chosen-driver-id')
+
+	it('calls changeDriver', async () => {
+		await expect(DriversSwitchCommand.run([
+			'--hub', 'arg-hub-id',
+			'--driver', 'arg-driver-id',
+			'arg-device-id',
+		])).resolves.not.toThrow()
+
+		expect(chooseHubMock).toHaveBeenCalledTimes(1)
+		expect(chooseHubMock).toHaveBeenCalledWith(expect.any(DriversSwitchCommand),
+			'Which hub is the device connected to?', 'arg-hub-id',
+			{ useConfigDefault: true })
+
+		expect(chooseDeviceMock).toHaveBeenCalledTimes(1)
+		expect(chooseDeviceMock).toHaveBeenCalledWith(
+			expect.any(DriversSwitchCommand),
+			'arg-device-id',
+			expect.objectContaining({
+				deviceListOptions: expect.objectContaining({
+					type: edgeDeviceIntegrationTypes }),
+				deviceListFilter: expect.any(Function) },
+			),
+		)
+
+		expect(chooseDriverMock).toHaveBeenCalledTimes(1)
+		expect(chooseDriverMock).toHaveBeenCalledWith(
+			expect.any(DriversSwitchCommand),
+			'Choose a driver to use.',
+			'arg-driver-id',
+			expect.objectContaining({ listItems: expect.any(Function) }),
+		)
+
+		expect(changeDriverSpy).toHaveBeenCalledTimes(1)
+		expect(changeDriverSpy).toHaveBeenCalledWith('chosen-driver-id', 'chosen-hub-id', 'chosen-device-id')
+	})
+
+	describe('deviceFilter', () => {
+		it.each(edgeDeviceIntegrationTypes)('includes %s devices on specified hub', async (deviceIntegrationType) => {
+			await expect(DriversSwitchCommand.run([])).resolves.not.toThrow()
+
+			const deviceListFilter = chooseDeviceMock.mock.calls[0][2]?.deviceListFilter
+			expect(deviceListFilter).toBeDefined()
+
+			const device = {
+				type: deviceIntegrationType,
+				[deviceIntegrationType.toString().toLowerCase()]: { hubId: 'chosen-hub-id' },
+			} as unknown as Device
+			expect(deviceListFilter?.(device, 0, [])).toBe(true)
+		})
+
+		it('rejects non-edge devices', async () => {
+			await expect(DriversSwitchCommand.run([])).resolves.not.toThrow()
+
+			const deviceListFilter = chooseDeviceMock.mock.calls[0][2]?.deviceListFilter
+			expect(deviceListFilter).toBeDefined()
+
+			const device = {
+				type: DeviceIntegrationType.ENDPOINT_APP,
+				app: { hubId: 'chosen-hub-id' },
+			} as unknown as Device
+			expect(deviceListFilter?.(device, 0, [])).toBe(false)
+		})
+
+		it('rejects edge devices on different hub', async () => {
+			await expect(DriversSwitchCommand.run([])).resolves.not.toThrow()
+
+			const deviceListFilter = chooseDeviceMock.mock.calls[0][2]?.deviceListFilter
+			expect(deviceListFilter).toBeDefined()
+
+			const device = {
+				type: DeviceIntegrationType.ZIGBEE,
+				zigbee: { hubId: 'other-hub-id' },
+			} as unknown as Device
+			expect(deviceListFilter?.(device, 0, [])).toBe(false)
+		})
+	})
+
+	describe('listItems', () => {
+		const matchingDriver = { driverId: 'matching-driver-id', name: 'Matching Driver' }
+		const matchingDrivers = [matchingDriver]
+		const listMatchingDriversMock = jest.mocked(listMatchingDrivers)
+			.mockResolvedValue(matchingDrivers)
+		const otherDriver = { driverId: 'other-driver-id', name: 'Other Driver' }
+		const allDrivers = [matchingDriver, otherDriver]
+		const listAllAvailableDriversMock = jest.mocked(listAllAvailableDrivers)
+			.mockResolvedValue(allDrivers)
+		it('uses listMatchingDrivers normally', async () => {
+			await expect(DriversSwitchCommand.run([])).resolves.not.toThrow()
+
+			const listItems = chooseDriverMock.mock.calls[0][3]?.listItems
+			expect(listItems).toBeDefined()
+			expect(await listItems?.()).toStrictEqual(matchingDrivers)
+
+			expect(listMatchingDriversMock).toHaveBeenCalledTimes(1)
+			expect(listMatchingDriversMock).toHaveBeenCalledWith(
+				expect.any(SmartThingsClient),
+				expect.any(EdgeClient),
+				'chosen-device-id', 'chosen-hub-id')
+			expect(listAllAvailableDriversMock).toHaveBeenCalledTimes(0)
+		})
+
+		it('lists all drivers when requested', async () => {
+			await expect(DriversSwitchCommand.run(['--include-non-matching'])).resolves.not.toThrow()
+
+			const listItems = chooseDriverMock.mock.calls[0][3]?.listItems
+			expect(listItems).toBeDefined()
+			expect(await listItems?.()).toStrictEqual(allDrivers)
+
+			expect(listMatchingDriversMock).toHaveBeenCalledTimes(0)
+			expect(listAllAvailableDriversMock).toHaveBeenCalledTimes(1)
+			expect(listAllAvailableDriversMock).toHaveBeenCalledWith(
+				expect.any(SmartThingsClient),
+				expect.any(EdgeClient),
+				'chosen-device-id', 'chosen-hub-id')
+		})
+	})
+})

--- a/test/unit/lib/commands/drivers-util.test.ts
+++ b/test/unit/lib/commands/drivers-util.test.ts
@@ -589,7 +589,7 @@ describe('drivers-util', () => {
 			listAssignedDriversMock.mockReturnValueOnce(driverChannelDetailsList)
 			getDriverChannelMetaInfoMock.mockRejectedValueOnce(Error('random error'))
 
-			expect(listAssignedDriversWithNames(client, 'channel-id')).rejects.toThrow(Error('random error'))
+			await expect(listAssignedDriversWithNames(client, 'channel-id')).rejects.toThrow(Error('random error'))
 
 			expect(listAssignedDriversMock).toHaveBeenCalledTimes(1)
 			expect(listAssignedDriversMock).toHaveBeenCalledWith('channel-id')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,6 @@
 	},
 	"include": [
 		"src/**/**.ts",
+		".eslintrc.js",
 	],
 }


### PR DESCRIPTION
<!-- Describe your pull request. -->

* first commit
  * added "edge:drivers:switch" command
  * added "edge:drivers:default" command
  * added support for specifying a device to "edge:drivers:installed" command
* second commit
  * added lint rules for avoiding floating promises and spacing around infix operators

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] Any required documentation has been added
- [x] I have added tests to cover my changes
